### PR TITLE
PRESS4-168 Add Marketplace section within Dashboard

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -9,9 +9,13 @@ import { AdvancedFeatures } from "./AdvancedFeatures";
 import { CustomizeStore } from "./CustomizeStore";
 import { GeneralSettings } from "./GeneralSettings";
 import { ManageProducts } from "./ManageProducts";
+import { Marketplace } from "./Marketplace";
 import { useOnboardingCleanup } from "./useOnboardingCleanup";
 import { useSetupYITHWonderTheme } from "./useSetupYITHWonderTheme";
 
+/**
+ * @param {string} stepKey
+ */
 function getStepName(stepKey) {
   switch (stepKey) {
     case "general":
@@ -22,6 +26,8 @@ function getStepName(stepKey) {
       return __("Pages", "wp-module-ecommerce");
     case "features":
       return __("Additional Features", "wp-module-ecommerce");
+    case "recommended":
+      return __("Recommended Plugins", "wp-module-ecommerce");
     default:
       return null;
   }
@@ -31,7 +37,8 @@ const guideSteps = [
   { key: "general", StepContent: GeneralSettings },
   { key: "products", StepContent: ManageProducts },
   { key: "pages", StepContent: CustomizeStore },
-  { key: "features", StepContent: AdvancedFeatures }
+  { key: "features", StepContent: AdvancedFeatures },
+  { key: "recommended", StepContent: Marketplace },
 ];
 
 export function Dashboard(props) {

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -44,11 +44,16 @@ const guideSteps = [
 export function Dashboard(props) {
   const { navigate } = props.wpModules;
   const isLargeViewport = useViewportMatch("mobile", ">=");
+  let isUpsellNeeded =
+    props.state.wp.isWooActive && !props.state.wp.isOnECommercePlan;
   let { key, StepContent } =
-    guideSteps.find((step) => step.key === props.section) ?? guideSteps[0];
+    guideSteps
+      .filter((step) =>
+        isUpsellNeeded ? step.key !== "features" : step.key !== "recommended"
+      )
+      .find((step) => step.key === props.section) ?? guideSteps[0];
   useSetupYITHWonderTheme();
   let isCleanUpInProgress = useOnboardingCleanup(props.plugins.token?.hash);
-  let addCurtain = props.plugins?.status?.woocommerce !== "Active";
   function onBackButtonClick() {
     navigate("/home/store");
   }

--- a/src/components/Marketplace.js
+++ b/src/components/Marketplace.js
@@ -1,0 +1,92 @@
+import apiFetch from "@wordpress/api-fetch";
+import {
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  CardMedia,
+  Spinner,
+  TabPanel,
+} from "@wordpress/components";
+import { useEffect, useState } from "@wordpress/element";
+import classnames from "classnames";
+
+const ui = {
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  CardMedia,
+  TabPanel,
+  Spinner,
+};
+
+const constants = {
+  resturl: window.nfdRestRoot,
+  eventendpoint: "/newfold-data/v1/events/",
+  perPage: 12,
+  supportsCTB: window.nfdConnected,
+};
+
+/**
+ * @typedef {Object} MarketplaceProduct
+ * @property {string} id UUID
+ * @property {string[]} categories Categories for the product
+ * @property {string} name Display name
+ * @property {"plugin" | "service" | "theme"} type
+ * @property {string} vendor_id UUID
+ * @property {{ name: string }?} vendor Vendor for the product. Can be YITH, Yoast etc.
+ */
+
+/**
+ * @typedef {Object} MarketplaceCategory
+ * @property {string} name Name of the category
+ * @property {number} product_count No. of products under this category
+ * @property {string} title Display title for UI
+ */
+
+/**
+ * @typedef {Object} MarketPlaceCollections
+ * @property {{ data: MarketplaceCategory[] }} categories
+ * @property {{ data: MarketplaceProduct[] }} products
+ */
+
+/**
+ * @param {MarketPlaceCollections} marketplace
+ */
+function onlyAllowECommerceProducts(marketplace) {
+  marketplace.categories.data = marketplace.categories.data.filter((category) =>
+    ["ecommerce", "featured"].includes(category.name)
+  );
+  marketplace.products.data = marketplace?.products?.data?.filter(
+    (product) => product.vendor?.name === "YITH"
+  );
+  return marketplace;
+}
+
+export function Marketplace({ wpModules }) {
+  let [pathname, navigate] = useState("/marketplace/ecommerce");
+
+  const methods = {
+    apiFetch: (args) => apiFetch(args).then(onlyAllowECommerceProducts),
+    classnames,
+    useState,
+    useEffect,
+    // To avoid actual path changes, we'll stub these hooks with local state.
+    useNavigate() {
+      return navigate;
+    },
+    useLocation() {
+      return { pathname };
+    },
+  };
+  return (
+    <wpModules.NewfoldMarketplace
+      Components={ui}
+      methods={methods}
+      constants={constants}
+    />
+  );
+}

--- a/src/components/useOnboardingCleanup.js
+++ b/src/components/useOnboardingCleanup.js
@@ -14,10 +14,10 @@ const HighProductVolumes = ['11-100', '101-1000', '1000+'];
 export function useOnboardingCleanup(hash) {
   let [cleanupStatus, setCleanupStatus] = useState(false);
   let { data: flow, error: flowError } = useSWRImmutable(
-    '/newfold-onboarding/v1/flow'
+    hash ? '/newfold-onboarding/v1/flow' : null
   );
   let { data: settings, error: settingsError } = useSWRImmutable(
-    Endpoints.WP_SETTINGS
+    hash ? Endpoints.WP_SETTINGS : null
   );
   useEffect(async () => {
     if (flow && settings && hash) {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,19 @@ import { Endpoints } from "./services";
 
 const fetcher = (path) => apiFetch({ path });
 
+/**
+ * @typedef {object} NewfoldECommerceOptions
+ * @property {{ wp: Record<string, boolean>}} state
+ * @property {Record<string, any>} wpModules
+ * @property {Record<string, any>} actions
+ * @property {string} section
+ */
+
+/**
+ *
+ * @param {NewfoldECommerceOptions} props
+ * @returns {import("react").ReactElement}
+ */
 window.NewfoldECommerce = function NewfoldECommerce(props) {
   let {
     data,
@@ -23,14 +36,14 @@ window.NewfoldECommerce = function NewfoldECommerce(props) {
     ...(data ?? {}),
     refresh: refreshPlugins,
   };
-  let Hero =
-    plugins.status?.woocommerce === "Active" ? Banner : WooCommerceUnavailable;
+  let isWooActive = props.state.wp.isWooActive;
+  let Hero = isWooActive ? Banner : WooCommerceUnavailable;
   return (
     <SWRConfig
       value={{
         fetcher,
         revalidateOnReconnect: false,
-        isPaused: () => plugins.status?.woocommerce !== "Active",
+        isPaused: () => !isWooActive,
       }}
     >
       <div className="nfd-ecommerce-atoms nfd-ecommerce-setup">


### PR DESCRIPTION
This PR embeds the Marketplace component within the eCommerce Dashboard as an upsell that is provided to users who have WooCommerce but aren't on the eCommerce package.

Currently, I had to employ some _hacks_ to get around the Marketplace component's navigation and rendering logic.

We can have a further conversation on how to provide specific API endpoints etc.