### PR TITLE
Add route_enable property to razorpay settings

### DIFF
--- a/includes/Partials/CaptiveFlow.php
+++ b/includes/Partials/CaptiveFlow.php
@@ -49,6 +49,9 @@ class CaptiveFlow {
 							'enable_1cc_debug_mode' => array(
 								'type' => 'string',
 							),
+							'route_enable' => array(
+								'type' => 'string',
+							),
 						),
 					),
 				),


### PR DESCRIPTION
`route_enable` is available as an option under WooRazorpay when WooCommerce default currency is set to `INR`. Accordingly, we expose this option when registering the razorpay settings.