### PR TITLE
Ensure Paypal BN Code is correct for our sites

### DIFF
--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -169,13 +169,16 @@ class ECommerce {
 	/**
 	 * Ensure that any retired BN codes are not sent with outbound requests to Paypal
 	 *
-	 * @return array
+	 * @param array  $parsed_args An array of HTTP request arguments
+	 * @param string $url         The request URL
+	 *
+	 * @return array Array of modified HTTP request arguments
 	 */
 	public function replace_retired_bn_codes( $parsed_args, $url ) {
 		try {
 			// Bail early if the request is not to paypal's v2 checkout API
-			if ( false === stripos( parse_url( $url,  PHP_URL_HOST ), 'paypal.com' )
-				&& false === stripos( parse_url( $url,  PHP_URL_PATH ), 'v2/checkout' ) ) {
+			if ( false === stripos( wp_parse_url( $url, PHP_URL_HOST ), 'paypal.com' )
+				&& false === stripos( wp_parse_url( $url, PHP_URL_PATH ), 'v2/checkout' ) ) {
 				return $parsed_args;
 			}
 
@@ -184,12 +187,12 @@ class ECommerce {
 
 			// Ensure we only set when blank, or when using one of our stale codes (not the current one)
 			if ( is_null( $bn_code ) ||
-				( $bn_code !== 'YITH_PCP' && ( false !== stripos( $bn_code, 'YITH' ) || false !== strpos( $bn_code, 'NEWFOLD' ) ) )
+				( 'YITH_PCP' !== $bn_code && ( false !== stripos( $bn_code, 'YITH' ) || false !== strpos( $bn_code, 'NEWFOLD' ) ) )
 			) {
 				// The correct code is case sensitive. YITH brand is uppercase, but the code is not.
 				$parsed_args['headers']['PayPal-Partner-Attribution-Id'] = 'Yith_PCP';
 			}
-		} catch (\Exception $e) {
+		} catch ( \Exception $e ) {
 			error_log( 'NFD: Unable to fix partner attribution.' );
 		} finally {
 			return $parsed_args;

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -54,7 +54,7 @@ class ECommerce {
 		'wc_connect_taxes_enabled',
 		'woocommerce_calc_taxes',
 		'woocommerce_currency',
-		'woocommerce_email_from_address'
+		'woocommerce_email_from_address',
 	);
 
 	/**
@@ -67,11 +67,11 @@ class ECommerce {
 		// Module functionality goes here
 		add_action( 'admin_bar_menu', array( $this, 'newfold_site_status' ), 200 );
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
-		add_action( 'load-toplevel_page_bluehost' , array( $this, 'register_assets') );
-		add_action( 'load-toplevel_page_crazy-domains' , array( $this, 'register_assets') );
+		add_action( 'load-toplevel_page_bluehost', array( $this, 'register_assets' ) );
+		add_action( 'load-toplevel_page_crazy-domains', array( $this, 'register_assets' ) );
 		add_filter( 'http_request_args', array( $this, 'replace_retired_bn_codes' ), 10, 2 );
 		CaptiveFlow::init();
-		WooCommerceBacklink::init($container );
+		WooCommerceBacklink::init( $container );
 		register_meta(
 			'post',
 			'nf_dc_page',
@@ -155,7 +155,7 @@ class ECommerce {
 	 */
 	public function register_assets() {
 		$asset_file = NFD_ECOMMERCE_BUILD_DIR . 'index.asset.php';
-		if ( file_exists($asset_file) ) {
+		if ( file_exists( $asset_file ) ) {
 			$asset = require_once $asset_file;
 			\wp_enqueue_script(
 				'nfd-ecommerce-dependency',

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -186,9 +186,7 @@ class ECommerce {
 			$bn_code = isset( $parsed_args['headers']['PayPal-Partner-Attribution-Id'] ) ? $parsed_args['headers']['PayPal-Partner-Attribution-Id'] : null;
 
 			// Ensure we only set when blank, or when using one of our stale codes (not the current one)
-			if ( is_null( $bn_code ) ||
-				( 'Yith_PCP' !== $bn_code && ( false !== stripos( $bn_code, 'yith' ) || false !== stripos( $bn_code, 'newfold' ) ) )
-			) {
+			if ( is_null( $bn_code ) || false !== stripos( $bn_code, 'yith' ) || false !== stripos( $bn_code, 'newfold' ) ) {
 				// The correct code is case sensitive. YITH brand is uppercase, but the code is not.
 				$parsed_args['headers']['PayPal-Partner-Attribution-Id'] = 'Yith_PCP';
 			}

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -183,11 +183,11 @@ class ECommerce {
 			}
 
 			// Check for an existing bn_code and normalize to uppercase
-			$bn_code = isset( $parsed_args['headers']['PayPal-Partner-Attribution-Id'] ) ? strtoupper( $parsed_args['headers']['PayPal-Partner-Attribution-Id'] ) : null;
+			$bn_code = isset( $parsed_args['headers']['PayPal-Partner-Attribution-Id'] ) ? $parsed_args['headers']['PayPal-Partner-Attribution-Id'] : null;
 
 			// Ensure we only set when blank, or when using one of our stale codes (not the current one)
 			if ( is_null( $bn_code ) ||
-				( 'YITH_PCP' !== $bn_code && ( false !== stripos( $bn_code, 'YITH' ) || false !== strpos( $bn_code, 'NEWFOLD' ) ) )
+				( 'Yith_PCP' !== $bn_code && ( false !== stripos( $bn_code, 'yith' ) || false !== stripos( $bn_code, 'newfold' ) ) )
 			) {
 				// The correct code is case sensitive. YITH brand is uppercase, but the code is not.
 				$parsed_args['headers']['PayPal-Partner-Attribution-Id'] = 'Yith_PCP';

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -175,25 +175,21 @@ class ECommerce {
 	 * @return array Array of modified HTTP request arguments
 	 */
 	public function replace_retired_bn_codes( $parsed_args, $url ) {
-		try {
-			// Bail early if the request is not to paypal's v2 checkout API
-			if ( false === stripos( wp_parse_url( $url, PHP_URL_HOST ), 'paypal.com' )
-				&& false === stripos( wp_parse_url( $url, PHP_URL_PATH ), 'v2/checkout' ) ) {
-				return $parsed_args;
-			}
-
-			// Check for an existing bn_code and normalize to uppercase
-			$bn_code = isset( $parsed_args['headers']['PayPal-Partner-Attribution-Id'] ) ? $parsed_args['headers']['PayPal-Partner-Attribution-Id'] : null;
-
-			// Ensure we only set when blank, or when using one of our stale codes (not the current one)
-			if ( is_null( $bn_code ) || false !== stripos( $bn_code, 'yith' ) || false !== stripos( $bn_code, 'newfold' ) ) {
-				// The correct code is case sensitive. YITH brand is uppercase, but the code is not.
-				$parsed_args['headers']['PayPal-Partner-Attribution-Id'] = 'Yith_PCP';
-			}
-		} catch ( \Exception $e ) {
-			error_log( 'NFD: Unable to fix partner attribution.' );
-		} finally {
+		// Bail early if the request is not to paypal's v2 checkout API
+		if ( false === stripos( wp_parse_url( $url, PHP_URL_HOST ), 'paypal.com' )
+			&& false === stripos( wp_parse_url( $url, PHP_URL_PATH ), 'v2/checkout' ) ) {
 			return $parsed_args;
 		}
+
+		// Check for an existing bn_code
+		$bn_code = isset( $parsed_args['headers']['PayPal-Partner-Attribution-Id'] ) ? $parsed_args['headers']['PayPal-Partner-Attribution-Id'] : null;
+
+		// Ensure we only set when blank, or when using one of our stale codes
+		if ( is_null( $bn_code ) || false !== stripos( $bn_code, 'yith' ) || false !== stripos( $bn_code, 'newfold' ) ) {
+			// The correct code is case sensitive. YITH brand is uppercase, but the code is not.
+			$parsed_args['headers']['PayPal-Partner-Attribution-Id'] = 'Yith_PCP';
+		}
+
+		return $parsed_args;
 	}
 }


### PR DESCRIPTION
This hooks into `http_request_args` and if the request is going the Paypal checkout API, then it checks to see if one of our stale BN codes is in use, or if it is not set at all, and ensures that the request is using the correct code.  