### PR TITLE
Update for PayPal BN codes

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -6,6 +6,7 @@ use NewfoldLabs\WP\Module\ECommerce\ECommerce;
 use function NewfoldLabs\WP\ModuleLoader\register;
 
 if ( function_exists( 'add_action' ) ) {
+
 	add_action(
 		'plugins_loaded',
 		function () {
@@ -23,6 +24,34 @@ if ( function_exists( 'add_action' ) ) {
 				)
 			);
 		}
+	);
+
+}
+
+if ( function_exists( 'add_filter' ) ) {
+
+	add_filter(
+		'http_request_args',
+		function ( $parsed_args, $url ) {
+
+			// Bail early if the request is not to PayPal's v2 checkout API
+			if ( false === stripos( wp_parse_url( $url, PHP_URL_HOST ), 'paypal.com' ) ) {
+				return $parsed_args;
+			}
+
+			// Check for an existing bn_code
+			$bn_code = isset( $parsed_args['headers']['PayPal-Partner-Attribution-Id'] ) ? $parsed_args['headers']['PayPal-Partner-Attribution-Id'] : null;
+
+			// Ensure we only set when blank, or when using one of our stale codes
+			if ( is_null( $bn_code ) || false !== stripos( $bn_code, 'yith' ) || false !== stripos( $bn_code, 'newfold' ) ) {
+				// The correct code is case-sensitive. YITH brand is uppercase, but the code is not.
+				$parsed_args['headers']['PayPal-Partner-Attribution-Id'] = 'Yith_PCP';
+			}
+
+			return $parsed_args;
+		},
+		10,
+		2
 	);
 
 }

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -156,7 +156,7 @@ class ECommerce {
 	public function register_assets() {
 		$asset_file = NFD_ECOMMERCE_BUILD_DIR . 'index.asset.php';
 		if ( file_exists( $asset_file ) ) {
-			$asset = require_once $asset_file;
+			$asset = require $asset_file;
 			\wp_enqueue_script(
 				'nfd-ecommerce-dependency',
 				NFD_ECOMMERCE_PLUGIN_URL . 'vendor/newfold-labs/wp-module-ecommerce/includes/Partials/load-dependencies.js',


### PR DESCRIPTION
Remove condition that checks for a specific endpoint.

Ensure that code always runs, even if the e-commerce module is disabled. Resolves #69 

Change out the `require_once` with `require` to ensure that the `index.asset.php` array from the file is always returned. A boolean is returned if `require_once` is called more than once. This code shouldn't run more than once, but if it did, it would break things.