### PR TITLE
Skip WC onboarding and stop redirect after activation

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -20,6 +20,8 @@ if ( function_exists( 'register_activation_hook' ) ) {
 		'woocommerce/woocommerce.php',
 		function () {
 			skip_woo_onboarding();
+			$is_redirect_allowed = strpos($_SERVER['REQUEST_URI'], 'wp-admin/plugins.php') !== false;
+			update_option( 'nfd_show_dash_after_woo_activation', $is_redirect_allowed );
 		}
 	);
 
@@ -51,9 +53,9 @@ if ( function_exists( 'add_action' ) ) {
 if ( function_exists( 'add_filter' ) ) {
 
 	add_filter(
-		'woocommerce_prevent_automatic_wizard_redirect',
+		'woocommerce_enable_setup_wizard',
 		function() {
-			return true;
+			return false;
 		}
 	);
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -5,6 +5,26 @@ use NewfoldLabs\WP\Module\ECommerce\ECommerce;
 
 use function NewfoldLabs\WP\ModuleLoader\register;
 
+function skip_woo_onboarding() {
+	$wc_option = 'woocommerce_onboarding_profile';
+	$skip_onboarding = array(
+		'skipped' => true,
+	);
+	$profile         = (array) get_option( $wc_option, array() );
+	update_option( $wc_option, array_merge( $profile, $skip_onboarding ) );
+}
+
+if ( function_exists( 'register_activation_hook' ) ) {
+
+	register_activation_hook(
+		'woocommerce/woocommerce.php',
+		function () {
+			skip_woo_onboarding();
+		}
+	);
+
+}
+
 if ( function_exists( 'add_action' ) ) {
 
 	add_action(
@@ -31,6 +51,13 @@ if ( function_exists( 'add_action' ) ) {
 if ( function_exists( 'add_filter' ) ) {
 
 	add_filter(
+		'woocommerce_prevent_automatic_wizard_redirect',
+		function() {
+			return true;
+		}
+	);
+
+	add_filter(
 		'http_request_args',
 		function ( $parsed_args, $url ) {
 
@@ -53,7 +80,7 @@ if ( function_exists( 'add_filter' ) ) {
 		10,
 		2
 	);
-	
+
 	add_filter(
 		'script_loader_tag',
 		function ( $tag, $handle, $source ) {

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -65,6 +65,7 @@ class ECommerce {
 	public function __construct( Container $container ) {
 		$this->container = $container;
 		// Module functionality goes here
+		add_action( 'admin_init', array( $this, 'maybe_do_dash_redirect' ) );
 		add_action( 'admin_bar_menu', array( $this, 'newfold_site_status' ), 200 );
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 		add_action( 'load-toplevel_page_bluehost', array( $this, 'register_assets' ) );
@@ -81,6 +82,14 @@ class ECommerce {
 				'single'       => true,
 			)
 		);
+	}
+
+	public function maybe_do_dash_redirect() {
+		$show_dash = get_option( 'nfd_show_dash_after_woo_activation', false );
+		if ( $show_dash && !wp_doing_ajax() ) {
+			update_option( 'nfd_show_dash_after_woo_activation', false );
+			wp_safe_redirect( admin_url('admin.php?page=' . $this->container->plugin()->id . '#/home') );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Given a user installs WooCommerce
When the plugin is activated
Then dismiss the WooCommerce onboarding
And redirect users to the Bluehost commerce hub 
 

Right now when a new WooCommerce plugin is installed, the WooCommerce onboarding steps take over and redirect to: `wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`