### PR TITLE
PRESS4-289-fixed percentage with rounding

### DIFF
--- a/src/components/ReportTile.js
+++ b/src/components/ReportTile.js
@@ -23,7 +23,7 @@ export function ReportTile(props) {
             <span
               className={sign > 0 ? "yst-text-green-600" : "yst-text-red-600"}
             >
-              <Icon className="yst-inline-block yst-h-3" /> {delta}%
+              <Icon className="yst-inline-block yst-h-3" /> {Math.round(delta)}%
             </span>
             {__(" vs prior period", "wp-module-ecommerce")}
           </div>


### PR DESCRIPTION
Fixed the percentages in Quick Look Recent Activity.

- Before:

<img width="1728" alt="Screenshot 2023-07-20 at 11 55 27 AM" src="https://github.com/newfold-labs/wp-module-ecommerce/assets/49781370/4c40f089-a95d-4218-b902-31795154e9b5">

- After:

<img width="1728" alt="Screenshot 2023-07-20 at 11 55 40 AM" src="https://github.com/newfold-labs/wp-module-ecommerce/assets/49781370/2b52a872-e2bd-4d0e-a179-9b2f72afb7c1">