### PR TITLE
show shadowbox based on props

### DIFF
--- a/hostgator.css
+++ b/hostgator.css
@@ -1,0 +1,15 @@
+:root {
+    --nfd-ecommerce-text-info: #495C77;
+    --nfd-ecommerce-text-secondary: #5B5B5B;
+    --nfd-ecommerce-text-light: #AAAFB8;
+    --nfd-ecomemerce-text-success: #17B212;
+    --nfd-ecommerce-text-dark-success: #048200;
+    --nfd-ecommerce-text-danger: #F72F26;
+    --nfd-ecommerce-text-dark: #404040;
+    
+    --nfd-ecommerce-bg-light: #F8FAFC;
+    --nfd-ecomemerce-bg-success: #178113;
+    --nfd-ecommerce-bg-secondary: #eff6fc;
+    --nfd-ecommerce-bg-danger: #E01C1C;
+    }
+    

--- a/src/components/FreePlugins.js
+++ b/src/components/FreePlugins.js
@@ -16,10 +16,10 @@ const Text = NewfoldRuntime.hasCapability("isEcommerce")
       "wp-module-ecommerce"
     );
 
-export function FreePlugins({ notify }) {
+export function FreePlugins({ notify, showShadowBox }) {
   let [cards] = useCardManager(FreePluginsDefinition({ notify }));
   return (
-    <Section.Container>
+    <Section.Container showShadowBox={showShadowBox}>
       <Section.Header
         title={__("Additional Features", "wp-module-ecommerce")}
         subTitle={Text}

--- a/src/components/OnboardingScreen.js
+++ b/src/components/OnboardingScreen.js
@@ -39,12 +39,12 @@ const Text = {
   },
 };
 
-export function OnboardingScreen({ comingSoon, toggleComingSoon, notify }) {
+export function OnboardingScreen({ comingSoon, toggleComingSoon, notify, showShadowBox }) {
   const { title, description, Illustration } = comingSoon
     ? Text.Pending
     : Text.Live;
   return (
-    <Section.Container className="wppbh-welcome-section">
+    <Section.Container className="wppbh-welcome-section" showShadowBox={showShadowBox}>
       <Section.Header title="Home" />
       <Section.Content className="wppbh-app-section-home">
         <div className="yst-flex yst-flex-col yst-gap-6">

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -1,11 +1,11 @@
 import { Button, Title } from "@yoast/ui-library";
 import classNames from "classnames";
 
-const Container = ({ className, children }) => {
+const Container = ({ className, children, showShadowBox = true }) => {
   return (
     <div
-      className={classNames(
-        "wppb-app-section-container yst-bg-white yst-w-full yst-rounded-lg yst-shadow",
+      className={classNames({"yst-shadow": showShadowBox},
+        "wppb-app-section-container yst-bg-white yst-w-full yst-rounded-lg ",
         className
       )}
     >


### PR DESCRIPTION
in hostgator, we don't want to show the box shadow for freeplugins and onboradung screen. SO, added the prop based on which we can add or remove the box shadow.
<img width="1728" alt="Screenshot 2023-08-21 at 3 56 38 PM" src="https://github.com/newfold-labs/wp-module-ecommerce/assets/80672694/b56f0524-7a55-4ef4-9851-994c34a8359d">

<img width="1728" alt="Screenshot 2023-08-21 at 3 56 20 PM" src="https://github.com/newfold-labs/wp-module-ecommerce/assets/80672694/2d1e9214-95b6-4578-89a1-e9e5089f238d">
