### PR TITLE
Keep Yoast SEO meta box collapsed in site editor by default

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -128,16 +128,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.2.21",
+            "version": "2.2.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "978198befc71de0b18fc1fc5a472c03b184b504a"
+                "reference": "fedc76ee3f3e3d57d20993b9f4c5fcfb2f8596aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/978198befc71de0b18fc1fc5a472c03b184b504a",
-                "reference": "978198befc71de0b18fc1fc5a472c03b184b504a",
+                "url": "https://api.github.com/repos/composer/composer/zipball/fedc76ee3f3e3d57d20993b9f4c5fcfb2f8596aa",
+                "reference": "fedc76ee3f3e3d57d20993b9f4c5fcfb2f8596aa",
                 "shasum": ""
             },
             "require": {
@@ -207,7 +207,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/2.2.21"
+                "source": "https://github.com/composer/composer/tree/2.2.22"
             },
             "funding": [
                 {
@@ -223,7 +223,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-15T12:07:40+00:00"
+            "time": "2023-09-29T08:53:46+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -885,16 +885,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "5.2.12",
+            "version": "v5.2.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "ad87d5a5ca981228e0e205c2bc7dfb8e24559b60"
+                "reference": "fbbe7e5d79f618997bc3332a6f49246036c45793"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/ad87d5a5ca981228e0e205c2bc7dfb8e24559b60",
-                "reference": "ad87d5a5ca981228e0e205c2bc7dfb8e24559b60",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/fbbe7e5d79f618997bc3332a6f49246036c45793",
+                "reference": "fbbe7e5d79f618997bc3332a6f49246036c45793",
                 "shasum": ""
             },
             "require": {
@@ -949,9 +949,9 @@
             ],
             "support": {
                 "issues": "https://github.com/justinrainbow/json-schema/issues",
-                "source": "https://github.com/justinrainbow/json-schema/tree/5.2.12"
+                "source": "https://github.com/justinrainbow/json-schema/tree/v5.2.13"
             },
-            "time": "2022-04-13T08:02:27+00:00"
+            "time": "2023-09-26T02:20:38+00:00"
         },
         {
             "name": "mck89/peast",
@@ -3543,16 +3543,16 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.20",
+            "version": "v0.11.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "d788a2c79e02f2f735fbb2b9a53db94d0e1bca4f"
+                "reference": "b3457a8d60cd0b1c48cab76ad95df136d266f0b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/d788a2c79e02f2f735fbb2b9a53db94d0e1bca4f",
-                "reference": "d788a2c79e02f2f735fbb2b9a53db94d0e1bca4f",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/b3457a8d60cd0b1c48cab76ad95df136d266f0b6",
+                "reference": "b3457a8d60cd0b1c48cab76ad95df136d266f0b6",
                 "shasum": ""
             },
             "require": {
@@ -3600,9 +3600,9 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.20"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.21"
             },
-            "time": "2023-09-01T12:21:35+00:00"
+            "time": "2023-09-29T15:28:10+00:00"
         },
         {
             "name": "wp-cli/rewrite-command",

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -90,6 +90,14 @@ class ECommerce {
 			)
 		);
 		add_filter( 'newfold-runtime', array( $this, 'add_to_runtime' ) );
+		add_filter( "postbox_classes_page_wpseo_meta", function( $classes ) {
+			$classes[] = 'closed';
+			return $classes;			
+		}, 10, 1 );
+		add_filter( "postbox_classes_post_wpseo_meta", function( $classes ) {
+			$classes[] = 'closed';
+			return $classes;			
+		}, 10, 1 );
 	}
 
 	/**

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -89,15 +89,34 @@ class ECommerce {
 				'single'       => true,
 			)
 		);
-		add_filter( 'newfold-runtime', array( $this, 'add_to_runtime' ) );
-		add_filter( "postbox_classes_page_wpseo_meta", function( $classes ) {
+		add_filter( 'newfold-runtime', array( $this, 'add_to_runtime' ) );		
+		$this->add_filters(array( 'postbox_classes_page_wpseo_meta', 'postbox_classes_post_wpseo_meta', 'postbox_classes_product_wpseo_meta' ), function( $classes ) {
 			$classes[] = 'closed';
 			return $classes;			
-		}, 10, 1 );
-		add_filter( "postbox_classes_post_wpseo_meta", function( $classes ) {
-			$classes[] = 'closed';
-			return $classes;			
-		}, 10, 1 );
+		});		
+	}
+
+	/**
+	 * Add multiple filters to a closure
+	 *
+	 * @param $tags
+	 * @param $function_to_add
+	 * @param int $priority
+	 * @param int $accepted_args
+	 *
+	 * @return bool true
+	*/
+	public static function add_filters($tags, $function_to_add, $priority = 10, $accepted_args = 1)
+	{
+	//If the filter names are not an array, create an array containing one item
+	if(!is_array($tags))
+		$tags = array($tags);
+
+	//For each filter name
+	foreach($tags as $index => $tag)
+		add_filter($tag, $function_to_add, (int)(is_array($priority) ? $priority[$index] : $priority), (int)(is_array($accepted_args) ? $accepted_args[$index] : $accepted_args));
+
+	return true;
 	}
 
 	/**


### PR DESCRIPTION
https://jira.newfold.com/browse/PRESS4-363

Description:
Given a customer has Yoast SEO plugin installed
When they are creating a new product, page, post, or anywhere else the meta-box shows
Then the Yoast meta-box is collapsed by default

Issue:
![image](https://github.com/newfold-labs/wp-module-ecommerce/assets/41899077/955e2c00-465a-42e8-a634-60f91b3ff72c)
