### PR TITLE
PRESS4-371 | Remove "Loaded" console log statement #147

### DIFF
--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -235,7 +235,7 @@ class ECommerce {
 			$asset = require $asset_file;
 			\wp_register_script(
 				'nfd-ecommerce-dependency',
-				NFD_ECOMMERCE_PLUGIN_URL . 'vendor/newfold-labs/wp-module-ecommerce/includes/Partials/load-dependencies.js',
+				null,
 				array_merge( $asset['dependencies'], array() ),
 				$asset['version']
 			);

--- a/includes/Partials/load-dependencies.js
+++ b/includes/Partials/load-dependencies.js
@@ -1,2 +1,0 @@
-//The actual JS is bundled with the Bluehost Plugin
-console.log("Loaded WP Dependencies For NFD-Ecommerce");


### PR DESCRIPTION
Description
We should remove the console log statement that states dependencies are loaded.

"Loaded WP Dependencies For NFD-Ecommerce" This is more a debugging statement and doesn't need to be exposed to customers in console logs.

This file is an extra resource that requires loading which also affects performance and plugin size.

<img width="1728" alt="Screenshot 2023-10-05 at 4 19 14 PM" src="https://github.com/newfold-labs/wp-module-ecommerce/assets/80672694/8b56a573-7693-4321-9be9-5b8cd44b6591">
