### PR TITLE
``wp-module-onboarding-data`` version bump to accept all the patch version 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   ],
   "require": {
     "newfold-labs/wp-module-installer": "^1.1",
-    "newfold-labs/wp-module-onboarding-data": "^0.0.2"
+    "newfold-labs/wp-module-onboarding-data": "^0.0"
   },
   "require-dev": {
     "newfold-labs/wp-php-standards": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24b445f7b242dff867d7e25974f849bf",
+    "content-hash": "384f77b7af2a01bf6cdfaf061a78f7b7",
     "packages": [
         {
             "name": "newfold-labs/wp-module-data",
@@ -99,16 +99,16 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",
-            "version": "0.0.2",
+            "version": "0.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding-data.git",
-                "reference": "d0c6c03d24c6b15e8516007146ac226a4af14449"
+                "reference": "6c8cef5e2efd0fb3678b122582979a1c4c580c87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/d0c6c03d24c6b15e8516007146ac226a4af14449",
-                "reference": "d0c6c03d24c6b15e8516007146ac226a4af14449",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/6c8cef5e2efd0fb3678b122582979a1c4c580c87",
+                "reference": "6c8cef5e2efd0fb3678b122582979a1c4c580c87",
                 "shasum": ""
             },
             "require": {
@@ -133,10 +133,10 @@
             ],
             "description": "A non-toggleable module containing a standardized interface for interacting with Onboarding data.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/0.0.2",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/0.0.3",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding-data/issues"
             },
-            "time": "2023-09-28T08:43:53+00:00"
+            "time": "2023-10-06T10:38:41+00:00"
         },
         {
             "name": "wp-forge/wp-query-builder",


### PR DESCRIPTION
``wp-module-onboarding-data`` : ^0.0.2 to ``wp-module-onboarding-data`` : ^0.0 

to accept all patch versions 