### PR TITLE
Add support for HostGator Latam & WonderCart brand customizations

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -6,7 +6,7 @@ use NewfoldLabs\WP\Module\ECommerce\ECommerce;
 use function NewfoldLabs\WP\ModuleLoader\register;
 
 function skip_woo_onboarding() {
-	$wc_option = 'woocommerce_onboarding_profile';
+	$wc_option       = 'woocommerce_onboarding_profile';
 	$skip_onboarding = array(
 		'skipped' => true,
 	);
@@ -20,7 +20,7 @@ if ( function_exists( 'register_activation_hook' ) ) {
 		'woocommerce/woocommerce.php',
 		function () {
 			skip_woo_onboarding();
-			$is_redirect_allowed = strpos($_SERVER['REQUEST_URI'], 'wp-admin/plugins.php') !== false;
+			$is_redirect_allowed = strpos( $_SERVER['REQUEST_URI'], 'wp-admin/plugins.php' ) !== false;
 			update_option( 'nfd_show_dash_after_woo_activation', $is_redirect_allowed );
 		}
 	);
@@ -56,7 +56,7 @@ if ( function_exists( 'add_filter' ) ) {
 
 	add_filter(
 		'woocommerce_enable_setup_wizard',
-		function() {
+		function () {
 			return false;
 		}
 	);
@@ -92,7 +92,7 @@ if ( function_exists( 'add_filter' ) ) {
 				$replacement = ' data-partner-attribution-id="Yith_PCP"';
 				if ( stripos( $tag, 'partner-attribution-id' ) === false ) {
 					$tag = str_replace( ' src=', $replacement . ' src=', $tag );
-				} else if ( stripos( $tag, 'NEWFOLD' ) || stripos( $tag, 'YITH' ) ) {
+				} elseif ( stripos( $tag, 'NEWFOLD' ) || stripos( $tag, 'YITH' ) ) {
 					$tag = preg_replace( '/ data-partner-attribution-id="(.*?)"/', $replacement, $tag );
 				}
 			}
@@ -101,11 +101,11 @@ if ( function_exists( 'add_filter' ) ) {
 		25,
 		3
 	);
-	
+
 	add_filter(
 		'yith_wcbk_is_request',
 		function ( $is_request, $type ) {
-		   return 'rest' === $type ? wp_is_json_request() : $is_request;
+			return 'rest' === $type ? wp_is_json_request() : $is_request;
 		},
 		10,
 		2

--- a/includes/Data/Brands.php
+++ b/includes/Data/Brands.php
@@ -7,7 +7,7 @@ use NewfoldLabs\WP\ModuleLoader\Container;
  */
 final class Brands {
 	private static function get_brand_name( Container $container ) {
-		$brand_raw_value  = $container->plugin()->brand;
+		$brand_raw_value = $container->plugin()->brand;
 		return \sanitize_title( str_replace( '_', '-', $brand_raw_value ) );
 	}
 	/**
@@ -16,76 +16,76 @@ final class Brands {
 	 * @return array
 	 */
 	public static function get_config( Container $container ) {
-		$brand = Brands::get_brand_name( $container );
-		switch ($brand) {
+		$brand = self::get_brand_name( $container );
+		switch ( $brand ) {
 			case 'crazy-domains':
 				return array(
-					'brand' => 'crazy-domains',
-					'name' => 'CrazyDomains',
-					'url' => 'https://crazydomains.com',
+					'brand'           => 'crazy-domains',
+					'name'            => 'CrazyDomains',
+					'url'             => 'https://crazydomains.com',
 					'hireExpertsInfo' => 'admin.php?page=crazy-domains#/marketplace/services/blue-sky',
-					'support' => 'https://www.crazydomains.in/contact',
-					'adminPage' => 'admin.php?page=crazy-domains',
-					'setup' => array(
-						'payment' => array('Paypal'),
-						'shipping' => array('Shippo'),
+					'support'         => 'https://www.crazydomains.in/contact',
+					'adminPage'       => 'admin.php?page=crazy-domains',
+					'setup'           => array(
+						'payment'  => array( 'Paypal' ),
+						'shipping' => array( 'Shippo' ),
 					),
-					'defaultContact' => array(
+					'defaultContact'  => array(
 						'woocommerce_default_country' => 'AU:NSW',
-						'woocommerce_currency' => 'AUD',
+						'woocommerce_currency'        => 'AUD',
 					),
 				);
 
 			case 'bluehost-india':
 				return array(
-					'brand' => 'bluehost-india',
-					'name' => 'Bluehost',
-					'url' => 'https://bluehost.in',
+					'brand'           => 'bluehost-india',
+					'name'            => 'Bluehost',
+					'url'             => 'https://bluehost.in',
 					'hireExpertsInfo' => 'https://www.bluehost.in/solutions/full-service',
-					'support' => 'https://helpchat.bluehost.in',
-					'adminPage' => 'admin.php?page=bluehost',
-					'setup' => array(
-						'payment' => array('Paypal', 'Razorpay'),
+					'support'         => 'https://helpchat.bluehost.in',
+					'adminPage'       => 'admin.php?page=bluehost',
+					'setup'           => array(
+						'payment'  => array( 'Paypal', 'Razorpay' ),
 						'shipping' => array(),
 					),
-					'defaultContact' => array(
+					'defaultContact'  => array(
 						'woocommerce_default_country' => 'IN:AP',
-						'woocommerce_currency' => 'INR',
+						'woocommerce_currency'        => 'INR',
 					),
 				);
 			case 'hostgator':
 				return array(
-					'brand' => 'hostgator',
-					'name' => 'hostgator',
-					'url' => 'https://hostgator.com',
+					'brand'           => 'hostgator',
+					'name'            => 'hostgator',
+					'url'             => 'https://hostgator.com',
 					'hireExpertsInfo' => 'admin.php?page=hostgator#/marketplace/services/blue-sky',
-					'support' => 'https://www.hostgator.com/contact',
-					'adminPage' => 'admin.php?page=hostgator',
-					'setup' => array(
-						'payment' => array('Paypal', 'Razorpay'),
+					'support'         => 'https://www.hostgator.com/contact',
+					'adminPage'       => 'admin.php?page=hostgator',
+					'setup'           => array(
+						'payment'  => array( 'Paypal', 'Razorpay' ),
 						'shipping' => array(),
 					),
-					'defaultContact' => array(
+					'defaultContact'  => array(
 						'woocommerce_default_country' => 'BR:AL',
-						'woocommerce_currency' => 'BRL',
+						'woocommerce_currency'        => 'BRL',
 					),
 				);
 			case 'bluehost':
 			default:
 				return array(
-					'brand' => 'bluehost',
-					'name' => 'Bluehost',
-					'url' => 'https://bluehost.com',
+					'brand'           => 'bluehost',
+					'name'            => 'Bluehost',
+					'url'             => 'https://bluehost.com',
 					'hireExpertsInfo' => 'admin.php?page=bluehost#/marketplace/services/blue-sky',
-					'support' => 'https://www.bluehost.com/contact',
-					'adminPage' => 'admin.php?page=bluehost',
-					'setup' => array(
-						'payment' => array('Paypal', 'Razorpay'),
-						'shipping' => array('Shippo'),
+					'support'         => 'https://www.bluehost.com/contact',
+					'adminPage'       => 'admin.php?page=bluehost',
+					'setup'           => array(
+						'payment'  => array( 'Paypal', 'Razorpay' ),
+						'shipping' => array( 'Shippo' ),
 					),
-					'defaultContact' => array(
+					'defaultContact'  => array(
 						'woocommerce_default_country' => 'US:AZ',
-						'woocommerce_currency' => 'USD',
+						'woocommerce_currency'        => 'USD',
 					),
 				);
 		}

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -6,6 +6,7 @@ use NewfoldLabs\WP\Module\ECommerce\Data\Brands;
 use NewfoldLabs\WP\Module\ECommerce\Partials\CaptiveFlow;
 use NewfoldLabs\WP\Module\ECommerce\Partials\WooCommerceBacklink;
 use NewfoldLabs\WP\Module\ECommerce\I18nService;
+use NewfoldLabs\WP\Module\ECommerce\WonderCart;
 use NewfoldLabs\WP\Module\Installer\Services\PluginInstaller;
 use NewfoldLabs\WP\ModuleLoader\Container;
 use NewfoldLabs\WP\Module\Onboarding\Data\Services\FlowService;
@@ -81,6 +82,13 @@ class ECommerce {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'register_assets' ) );
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'register_textdomains' ) );
+
+		// Handle WonderCart Integrations
+		if ( is_plugin_active( 'wonder-cart/init.php' ) ) {
+			$wonder_cart = new WonderCart( $container );
+			$wonder_cart->init();
+		}
+
 		CaptiveFlow::init();
 		WooCommerceBacklink::init( $container );
 		register_meta(

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -89,6 +89,21 @@ class ECommerce {
 			$wonder_cart->init();
 		}
 
+		// Temporary Yith Paypal filters for Brazilian sites
+		if ( get_locale() === 'pt_BR' ) {
+			add_filter( 'yith_ppwc_is_custom_credit_card_enabled', '__return_false' );
+			add_filter( 'yith_paypal_payments_remove_cc_settings', '__return_true' );
+			add_filter(
+				'yith_paypal_payments_login_url_params',
+				function () {
+					$args['country.x']   = 'BR';
+					$args['countryCode'] = 'BR';
+					$args['product']     = 'EXPRESS_CHECKOUT';
+					return $args;
+				}
+			);
+		}
+
 		CaptiveFlow::init();
 		WooCommerceBacklink::init( $container );
 		register_meta(

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -60,8 +60,8 @@ class ECommerce {
 		'woocommerce_currency',
 		'woocommerce_email_from_address',
 		'woocommerce_bacs_settings',
-        'woocommerce_cod_settings',
-        'woocommerce_cheque_settings',
+		'woocommerce_cod_settings',
+		'woocommerce_cheque_settings',
 		'onboarding_experience_level',
 		'yoast_seo_signup_status',
 	);
@@ -73,7 +73,7 @@ class ECommerce {
 	 */
 	public function __construct( Container $container ) {
 		$this->container = $container;
-		// Module functionality goes here		
+		// Module functionality goes here
 		add_action( 'init', array( $this, 'load_php_textdomain' ) );
 		add_action( 'init', array( $this, 'load_experience_level' ) );
 		add_action( 'admin_init', array( $this, 'maybe_do_dash_redirect' ) );
@@ -93,11 +93,14 @@ class ECommerce {
 				'single'       => true,
 			)
 		);
-		add_filter( 'newfold-runtime', array( $this, 'add_to_runtime' ) );		
-		$this->add_filters(array( 'postbox_classes_page_wpseo_meta', 'postbox_classes_post_wpseo_meta', 'postbox_classes_product_wpseo_meta' ), function( $classes ) {
-			$classes[] = 'closed';
-			return $classes;			
-		});		
+		add_filter( 'newfold-runtime', array( $this, 'add_to_runtime' ) );
+		$this->add_filters(
+			array( 'postbox_classes_page_wpseo_meta', 'postbox_classes_post_wpseo_meta', 'postbox_classes_product_wpseo_meta' ),
+			function ( $classes ) {
+				$classes[] = 'closed';
+				return $classes;
+			}
+		);
 	}
 
 	/**
@@ -105,22 +108,23 @@ class ECommerce {
 	 *
 	 * @param $tags
 	 * @param $function_to_add
-	 * @param int $priority
-	 * @param int $accepted_args
+	 * @param int             $priority
+	 * @param int             $accepted_args
 	 *
 	 * @return bool true
-	*/
-	public static function add_filters($tags, $function_to_add, $priority = 10, $accepted_args = 1)
-	{
-	//If the filter names are not an array, create an array containing one item
-	if(!is_array($tags))
-		$tags = array($tags);
+	 */
+	public static function add_filters( $tags, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+		// If the filter names are not an array, create an array containing one item
+		if ( ! is_array( $tags ) ) {
+			$tags = array( $tags );
+		}
 
-	//For each filter name
-	foreach($tags as $index => $tag)
-		add_filter($tag, $function_to_add, (int)(is_array($priority) ? $priority[$index] : $priority), (int)(is_array($accepted_args) ? $accepted_args[$index] : $accepted_args));
+		// For each filter name
+		foreach ( $tags as $index => $tag ) {
+			add_filter( $tag, $function_to_add, (int) ( is_array( $priority ) ? $priority[ $index ] : $priority ), (int) ( is_array( $accepted_args ) ? $accepted_args[ $index ] : $accepted_args ) );
+		}
 
-	return true;
+		return true;
 	}
 
 	/**
@@ -142,19 +146,19 @@ class ECommerce {
 	public function add_to_runtime( $sdk ) {
 		$values = array(
 			'brand_settings' => Brands::get_config( $this->container ),
-			'nonces' => array(
-				'gateway_toggle' => \wp_create_nonce( 'woocommerce-toggle-payment-gateway-enabled' )
+			'nonces'         => array(
+				'gateway_toggle' => \wp_create_nonce( 'woocommerce-toggle-payment-gateway-enabled' ),
 			),
-			'install_token' => PluginInstaller::rest_get_plugin_install_hash()
+			'install_token'  => PluginInstaller::rest_get_plugin_install_hash(),
 		);
 		return array_merge( $sdk, array( 'ecommerce' => $values ) );
 	}
 
 	public function maybe_do_dash_redirect() {
 		$show_dash = get_option( 'nfd_show_dash_after_woo_activation', false );
-		if ( $show_dash && !wp_doing_ajax() ) {
+		if ( $show_dash && ! wp_doing_ajax() ) {
 			update_option( 'nfd_show_dash_after_woo_activation', false );
-			wp_safe_redirect( admin_url('admin.php?page=' . $this->container->plugin()->id . '#/home') );
+			wp_safe_redirect( admin_url( 'admin.php?page=' . $this->container->plugin()->id . '#/home' ) );
 		}
 	}
 
@@ -213,10 +217,10 @@ class ECommerce {
 				'description'  => __( 'NFD eCommerce Options', 'wp-module-ecommerce' ),
 			)
 		);
-		$payments = array(
+		$payments                    = array(
 			'woocommerce_bacs_settings',
 			'woocommerce_cod_settings',
-			'woocommerce_cheque_settings'
+			'woocommerce_cheque_settings',
 		);
 		$schema_for_offline_payments = array(
 			'show_in_rest' => array(
@@ -226,13 +230,13 @@ class ECommerce {
 						'gateway_id' => array(
 							'type' => 'string',
 						),
-						'enabled' => array(
+						'enabled'    => array(
 							'type' => 'string',
 						),
-						'action' => array(
+						'action'     => array(
 							'type' => 'string',
 						),
-						'security' => array(
+						'security'   => array(
 							'type' => 'string',
 						),
 					),
@@ -242,7 +246,7 @@ class ECommerce {
 			'description'  => __( 'NFD eCommerce Options', 'wp-module-ecommerce' ),
 		);
 		foreach ( $payments as $payment ) {
-			\register_setting( 'general', $payment, $schema_for_offline_payments);
+			\register_setting( 'general', $payment, $schema_for_offline_payments );
 		}
 	}
 
@@ -260,7 +264,7 @@ class ECommerce {
 			$site_status_menu = array(
 				'id'     => 'site-status',
 				'parent' => 'top-secondary',
-				'href'   => admin_url('admin.php?page=' . $this->container->plugin()->id . '&nfd-target=coming-soon-section#/settings'),
+				'href'   => admin_url( 'admin.php?page=' . $this->container->plugin()->id . '&nfd-target=coming-soon-section#/settings' ),
 				'title'  => '<div style="background-color: #F8F8F8; padding: 0 16px;color:#333333;">' . esc_html__( 'Site Status: ', 'wp-module-ecommerce' ) . $status . '</div>',
 				'meta'   => array(
 					'title' => esc_attr__( 'Launch Your Site', 'wp-module-ecommerce' ),
@@ -300,5 +304,4 @@ class ECommerce {
 			\wp_enqueue_script( 'nfd-ecommerce-dependency' );
 		}
 	}
-
 }

--- a/includes/WonderCart.php
+++ b/includes/WonderCart.php
@@ -1,0 +1,140 @@
+<?php
+namespace NewfoldLabs\WP\Module\ECommerce;
+
+use NewfoldLabs\WP\ModuleLoader\Container;
+/**
+ * WonderCart Integration Class
+ */
+class WonderCart {
+	/**
+	 * Holds the container object
+	 *
+	 * @var Container
+	 */
+	public $container;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Container $container Plugin container
+	 */
+	public function __construct( Container $container ) {
+		$this->container = $container;
+	}
+
+	/**
+	 * Initialize WonderCart Integrations
+	 *
+	 * @return void
+	 */
+	public function init() {
+		// For now these are only customized on Hostgator.
+		// If in the future we need to expand this to other brands,
+		// the brand checks could be moved into the individual methods.
+		if ( $this->container->plugin()->brand === 'Hostgator' ) {
+			add_filter( 'yith_sales_panel_page', array( $this, 'get_panel_page' ) );
+			add_filter( 'yith_sales_main_panel_page', array( $this, 'get_main_panel_page' ) );
+			add_filter( 'yith_sales_main_app_id', array( $this, 'get_main_app_id' ) );
+			add_filter( 'yith_sales_get_scripts_data', array( $this, 'filter_scripts_data' ), 10, 2 );
+		}
+	}
+
+	/**
+	 * Returns the panel page
+	 *
+	 * @return string
+	 */
+	public function get_panel_page() {
+		// Only for Hostgator
+		return 'hostgator#/home/store/sales_discounts';
+	}
+
+	/**
+	 * Returns the main panel page
+	 *
+	 * @return string
+	 */
+	public function get_main_panel_page() {
+		// Only for Hostgator
+		return 'hostgator';
+	}
+
+	/**
+	 * Returns the main app ID
+	 *
+	 * @return string
+	 */
+	public function get_main_app_id() {
+		// Only for Hostgator
+		return '#hwa-app';
+	}
+
+	/**
+	 * Modifies and returns the primary scripts data array to apply themeing
+	 *
+	 * @param array  $params Array of data being filtered
+	 * @param string $handle The handle of the page in wp-admin where this is being loaded
+	 * @return array The filtered array
+	 */
+	public function filter_scripts_data( $params, $handle ) {
+		// Ensure we only apply this on the correct admin page
+		if ( 'yith-sales-admin' === $handle ) {
+			// Hostgator Branding
+			$params['uiLibraryColors'] = array(
+				'button'             => array(
+					'borderRadius' => '6px',
+					'contained'    => array(
+						'background'               => '#2E93EE!important',
+						'backgroundColor'          => '#2E93EE',
+						'color'                    => '#fff!important',
+						'&:hover'                  => array(
+							'background'      => '#1F2044!important',
+							'backgroundColor' => '#1F2044',
+							'color'           => '#FFF!important',
+						),
+						'&:focus, &:focus-visible' => array(
+							'boxShadow' => '0 0 0 1px #fff, 0 0 0 2px #2E93EE',
+						),
+						'&:disabled'               => array(
+							'opacity'         => 1,
+							'background'      => '#CDD8DF',
+							'backgroundColor' => '#CDD8DF',
+							'color'           => '#999',
+						),
+					),
+					'outlined'     => array(
+						'background'               => '#fff!important',
+						'backgroundColor'          => '#fff',
+						'color'                    => '#000!important',
+						'border'                   => '1px solid #2E93EE',
+						'&:hover'                  => array(
+							'background'      => '#cadded!important',
+							'backgroundColor' => '#cadded',
+							'border'          => '#949fb2',
+						),
+						'&:focus, &:focus-visible' => array(
+							'boxShadow' => '0 0 0 1px #fff, 0 0 0 2px #2E93EE',
+						),
+						'&:disabled'               => array(
+							'opacity'         => 1,
+							'background'      => '#fff',
+							'backgroundColor' => '#fff',
+							'border'          => '1px solid #949fb2',
+							'color'           => '#999999',
+						),
+					),
+				),
+				'primary'            => '#2E93EE',
+				'primaryHover'       => '#1F2044!important',
+				'primaryHoverBorder' => '#2E93EE',
+				'focusedBorderColor' => '#2E93EE!important',
+				'success'            => '#348528',
+				'tabs'               => array(
+					'activeTab' => '#1f2044',
+					'hoverTab'  => '#cdd8df',
+				),
+			);
+		}
+		return $params;
+	}
+}


### PR DESCRIPTION
These are filters suggested by @andreagrillo for ensuring proper support for WonderCart and Yith Paypal for Hostgator Latam. In particular, Brazilian sites would be affected. 

There are 2 main things to look at:
1. I created a new `WonderCart` class to hold these and any future WonderCart integrations we might need. This is wrapped in a check to confirm the WonderCart plugin is active first. 

1. I also added 3 filters to adjust Yith Paypal functionality for sites in Brazil. It checks for a `pt_BR` locale before adding them. These should be temporary until we can get them handled in the Yith Paypal plugin. 

We can check with @MikeHansenMe, @chrisdavidmiles, and @searunt to confirm correct functionality. 

---
Additional Side Note: There are quite a lot of PHPCS issues in this module. I fixed the whitespace issues for the files that I touched, but I did not fix the docblock issues. Given the many lines touched, I would recommend reviewing this PR with whitespace changes ignored to reduce the noise. 