### PR TITLE
Version bump of Ecommerce to 1.3.3 

### DIFF
--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => 'a8acefcf3189e6d9b78a');
+<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => '753c003a3999a2f493ca');

--- a/composer.lock
+++ b/composer.lock
@@ -99,16 +99,16 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding-data.git",
-                "reference": "6c8cef5e2efd0fb3678b122582979a1c4c580c87"
+                "reference": "ee9f3cbde7d3999487b3cf3bc8742b47f9a0d6d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/6c8cef5e2efd0fb3678b122582979a1c4c580c87",
-                "reference": "6c8cef5e2efd0fb3678b122582979a1c4c580c87",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/ee9f3cbde7d3999487b3cf3bc8742b47f9a0d6d8",
+                "reference": "ee9f3cbde7d3999487b3cf3bc8742b47f9a0d6d8",
                 "shasum": ""
             },
             "require": {
@@ -133,10 +133,10 @@
             ],
             "description": "A non-toggleable module containing a standardized interface for interacting with Onboarding data.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/0.0.3",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/0.0.4",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding-data/issues"
             },
-            "time": "2023-10-06T10:38:41+00:00"
+            "time": "2023-10-17T06:14:05+00:00"
         },
         {
             "name": "wp-forge/wp-query-builder",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newfold-labs/wp-module-ecommerce",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@newfold-labs/wp-module-ecommerce",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@faizaanceg/pandora": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@newfold-labs/wp-module-ecommerce",
   "description": "Brand Agnostic eCommerce Experience",
   "license": "GPL-2.0-or-later",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "build/index.js",
   "files": [
     "build/",


### PR DESCRIPTION
Changed the version of ``wp-module-ecommerce`` from ``1.3.2`` to ``1.3.3``.

This version includes the translations for Jira tickets PRESS4-357, PRESS4-358 && PRESS4-359 in Portuguese (pt_BR).