### PR TITLE
Ecommerce version changed to `1.3.8`

### DIFF
--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => 'b3f83f29834463a274f5');
+<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => 'e076e1d03f91ef19a291');

--- a/composer.lock
+++ b/composer.lock
@@ -99,16 +99,16 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding-data.git",
-                "reference": "145119e6f2e39d6a1af0f95af495f76f336fcd13"
+                "reference": "4735ce96add2e17253e434c38a1b613bd36b2cf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/145119e6f2e39d6a1af0f95af495f76f336fcd13",
-                "reference": "145119e6f2e39d6a1af0f95af495f76f336fcd13",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/4735ce96add2e17253e434c38a1b613bd36b2cf4",
+                "reference": "4735ce96add2e17253e434c38a1b613bd36b2cf4",
                 "shasum": ""
             },
             "require": {
@@ -133,10 +133,10 @@
             ],
             "description": "A non-toggleable module containing a standardized interface for interacting with Onboarding data.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/0.0.5",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/0.0.6",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding-data/issues"
             },
-            "time": "2023-10-20T10:39:26+00:00"
+            "time": "2023-11-01T10:30:53+00:00"
         },
         {
             "name": "wp-forge/wp-query-builder",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newfold-labs/wp-module-ecommerce",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@newfold-labs/wp-module-ecommerce",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@faizaanceg/pandora": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@newfold-labs/wp-module-ecommerce",
   "description": "Brand Agnostic eCommerce Experience",
   "license": "GPL-2.0-or-later",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "build/index.js",
   "files": [
     "build/",


### PR DESCRIPTION
Ecommerce version changed to `1.3.8`

##

1. Changes related to new version of paypal & shippo 
 https://downloads.yithemes.com/?apiRequest=download_extended&package=yith-shippo-shippings-for-woocommerce
 https://downloads.yithemes.com/?apiRequest=download_extended&package=yith-paypal-payments-for-woocommerce
2. Auto reload the screen, once Razor Pay is connected && Woocommerce installed to view the changes without user installing it manually
3. Home | Next Steps | New Order Received