### PR TITLE
Removed temporary paypal code && version bump of ecommerce to 1.3.9

### DIFF
--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => 'e076e1d03f91ef19a291');
+<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => 'b411e7fa1e5e99ae3542');

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -90,21 +90,6 @@ class ECommerce {
 			$wonder_cart->init();
 		}
 
-		// Temporary Yith Paypal filters for Brazilian sites
-		if ( get_locale() === 'pt_BR' ) {
-			add_filter( 'yith_ppwc_is_custom_credit_card_enabled', '__return_false' );
-			add_filter( 'yith_paypal_payments_remove_cc_settings', '__return_true' );
-			add_filter(
-				'yith_paypal_payments_login_url_params',
-				function () {
-					$args['country.x']   = 'BR';
-					$args['countryCode'] = 'BR';
-					$args['product']     = 'EXPRESS_CHECKOUT';
-					return $args;
-				}
-			);
-		}
-
 		CaptiveFlow::init();
 		WooCommerceBacklink::init( $container );
 		register_meta(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newfold-labs/wp-module-ecommerce",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@newfold-labs/wp-module-ecommerce",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@faizaanceg/pandora": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@newfold-labs/wp-module-ecommerce",
   "description": "Brand Agnostic eCommerce Experience",
   "license": "GPL-2.0-or-later",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "main": "build/index.js",
   "files": [
     "build/",

--- a/src/components/useInstallWonderCart.js
+++ b/src/components/useInstallWonderCart.js
@@ -8,14 +8,14 @@ import { sleep } from "../sdk/sleep";
 export function useInstallWonderCart({ wpModules }) {
   let { notify } = wpModules;
   let installWonderCart = useSWRMutation("install-nfd_slug_wonder_cart", async () => {
-    let response = await PluginsSdk.actions.installSync("nfd_slug_wonder_cart", true);
+    let response = await PluginsSdk.actions.installSync("nfd_slug_wonder_cart");
     if (response !== "failed") {
       notify.push("nfd_slug_wonder_cart-install-status", {
         title: "Installed successfully",
         variant: "success",
       });
       await sleep(1000);
-      // window.location.reload();
+      window.location.reload();
     } else {
       notify.push("nfd_slug_wonder_cart-install-status", {
         title: "Failed to install",

--- a/src/components/useInstallWoo.js
+++ b/src/components/useInstallWoo.js
@@ -8,8 +8,8 @@ export function useInstallWoo({ woo, wpModules }) {
   let needsSyncInstall = woo.needsInstall;
   let installWooCommerce = useSWRMutation("install-woo", async () => {
     let response = needsSyncInstall
-      ? await PluginsSdk.actions.installSync("woocommerce", true)
-      : await PluginsSdk.actions.queueInstall("woocommerce", true);
+      ? await PluginsSdk.actions.installSync("woocommerce")
+      : await PluginsSdk.actions.queueInstall("woocommerce");
     if (response !== "failed") {
       console.log(response, "testingggg");
       notify.push("woo-install-status", {

--- a/src/sdk/plugins.js
+++ b/src/sdk/plugins.js
@@ -23,21 +23,21 @@ export const PluginsSdk = {
     },
   },
   actions: {
-    async installSync(plugin, reload = false) {
+    async installSync(plugin) {
       return apiFetch({
         url: Endpoints.PLUGIN_INSTALL,
         method: "POST",
         headers: { "X-NFD-INSTALLER": INSTALL_TOKEN },
         data: { plugin, activate: true, queue: false },
-      }).then(() =>{ reload && window.location.reload() }).catch((error) => "failed");
+      }).catch((error) => "failed");
     },
-    async queueInstall(plugin, priority = 10, reload = false) {
+    async queueInstall(plugin, priority = 10) {
       return apiFetch({
         url: Endpoints.PLUGIN_INSTALL,
         method: "POST",
         headers: { "X-NFD-INSTALLER": INSTALL_TOKEN },
         data: { plugin, activate: true, queue: true, priority },
-      }).then(() =>{ reload && window.location.reload() }).catch((error) => "failed");
+      }).catch((error) => "failed");
     },
   },
 };


### PR DESCRIPTION
Removed [temporary code ]( https://github.com/newfold-labs/wp-module-ecommerce/pull/152/commits/8b14b34e89d4333e3da96609dde67f0f9ba832d5)
&& auto reload of woocommerce installed 
 version bump of ecommerce to 1.3.9