### PR TITLE
Hidding the setup list of woocommerce

### DIFF
--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -83,6 +83,7 @@ class ECommerce {
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'register_assets' ) );
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'register_textdomains' ) );
 		add_action('wp_body_open', array( $this, 'regiester_site_preview' ));
+		add_action('before_woocommerce_init', array( $this,'hide_woocommerce_set_up') );
 
 		// Handle WonderCart Integrations
 		if ( is_plugin_active( 'wonder-cart/init.php' ) ) {
@@ -322,5 +323,16 @@ class ECommerce {
 		if($is_coming_soon){
 		echo "<div style='background-color: #e71616; padding: 0 16px;color:#ffffff;font-size:16px;text-align:center;font-weight: 590;'>" . esc_html__( 'Site Preview - This site is NOT LIVE, only admins can see this view.', 'wp-module-ecommerce' ) . "</div>";
 		}
+	}
+	public function hide_woocommerce_set_up() {
+		$hidden_list = get_option('woocommerce_task_list_hidden_lists', []);
+		if(! in_array("setup", $hidden_list)){
+			$woocommerce_list = array_merge(get_option('woocommerce_task_list_hidden_lists', []),array(
+				"setup" 
+			));
+			// $woocommerce_list = array("setup");
+			update_option('woocommerce_task_list_hidden_lists', $woocommerce_list);
+		}
+		
 	}
 }


### PR DESCRIPTION
Updating `woocommerce_task_list_hidden_lists` column in database on `before_woocommerce_init` hook

<img width="1159" alt="Screenshot 2023-11-27 at 4 34 36 PM" src="https://github.com/newfold-labs/wp-module-ecommerce/assets/80672694/fa1c3000-2d75-436b-818a-eeb6b2f663c9">
