### PR TITLE
PRESS4-408 Cart Page - Remove Banner Distractions

### DIFF
--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => '35a585d23ab926dc7cd8');
+<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => '31c7e6c7b728cb452de1');

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -83,6 +83,7 @@ class ECommerce {
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'register_assets' ) );
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'register_textdomains' ) );
 		add_action('wp_body_open', array( $this, 'regiester_site_preview' ));
+		add_filter('woocommerce_before_cart', array( $this, 'hide_coupon_notice_on_cart'));
 
 		// Handle WonderCart Integrations
 		if ( is_plugin_active( 'wonder-cart/init.php' ) ) {
@@ -321,6 +322,22 @@ class ECommerce {
 		$is_coming_soon   = 'true' === get_option( 'nfd_coming_soon', 'false' );
 		if($is_coming_soon){
 		echo "<div style='background-color: #e71616; padding: 0 16px;color:#ffffff;font-size:16px;text-align:center;font-weight: 590;'>" . esc_html__( 'Site Preview - This site is NOT LIVE, only admins can see this view.', 'wp-module-ecommerce' ) . "</div>";
+		}
+	}
+
+	/**
+ 	* Remove Coupon notices and Add coupon field on cart page
+ 	*/
+
+ 	public function hide_coupon_notice_on_cart() {
+		if (is_cart()) {
+			?>
+			<style>
+				.woocommerce-info, .coupon {
+					display: none !important;
+				}
+			</style>
+			<?php
 		}
 	}
 }

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -83,7 +83,7 @@ class ECommerce {
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'register_assets' ) );
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'register_textdomains' ) );
 		add_action('wp_body_open', array( $this, 'regiester_site_preview' ));
-		add_filter('woocommerce_before_cart', array( $this, 'hide_coupon_notice_on_cart'));
+		add_filter( 'woocommerce_coupons_enabled',  array( $this, 'disable_coupon_field_on_cart' ) );
 
 		// Handle WonderCart Integrations
 		if ( is_plugin_active( 'wonder-cart/init.php' ) ) {
@@ -326,18 +326,12 @@ class ECommerce {
 	}
 
 	/**
- 	* Remove Coupon notices and Add coupon field on cart page
+ 	* Remove Add coupon field on cart page
  	*/
-
- 	public function hide_coupon_notice_on_cart() {
-		if (is_cart()) {
-			?>
-			<style>
-				.woocommerce-info, .coupon {
-					display: none !important;
-				}
-			</style>
-			<?php
-		}
-	}
+	public function disable_coupon_field_on_cart( $enabled ) {
+        if ( is_cart() ) {
+            $enabled = false;
+        }
+        return $enabled;
+    }
 }

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -84,6 +84,7 @@ class ECommerce {
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'register_textdomains' ) );
 		add_action('wp_body_open', array( $this, 'regiester_site_preview' ));
 		add_filter( 'woocommerce_coupons_enabled',  array( $this, 'disable_coupon_field_on_cart' ) );
+		add_filter( 'woocommerce_before_cart', array( $this, 'hide_banner_notice_on_cart'));
 
 		// Handle WonderCart Integrations
 		if ( is_plugin_active( 'wonder-cart/init.php' ) ) {
@@ -334,4 +335,19 @@ class ECommerce {
         }
         return $enabled;
     }
+
+	/**
+ 	* Remove notice banner on cart page
+ 	*/
+ 	public function hide_banner_notice_on_cart() {
+		if (is_cart()) {
+			?>
+			<style>
+				.wc-block-components-notice-banner, .ywgc_enter_code {
+					display: none;
+				}
+			</style>
+			<?php
+		}
+	}
 }


### PR DESCRIPTION
PRESS4-408 Removed Coupon notice and coupon field from the Cart page.

![image](https://github.com/newfold-labs/wp-module-ecommerce/assets/149479917/474153cd-a144-4268-b396-694b6aa7babe)
