### PR TITLE
Fix/hostgator wondercart issue

### DIFF
--- a/includes/WonderCart.php
+++ b/includes/WonderCart.php
@@ -31,7 +31,7 @@ class WonderCart {
 		// For now these are only customized on Hostgator.
 		// If in the future we need to expand this to other brands,
 		// the brand checks could be moved into the individual methods.
-		if ( $this->container->plugin()->brand === 'Hostgator' ) {
+		if ( $this->container->plugin()->brand === 'hostgator' ) {
 			add_filter( 'yith_sales_panel_page', array( $this, 'get_panel_page' ) );
 			add_filter( 'yith_sales_main_panel_page', array( $this, 'get_main_panel_page' ) );
 			add_filter( 'yith_sales_main_app_id', array( $this, 'get_main_app_id' ) );

--- a/includes/WonderCart.php
+++ b/includes/WonderCart.php
@@ -31,7 +31,7 @@ class WonderCart {
 		// For now these are only customized on Hostgator.
 		// If in the future we need to expand this to other brands,
 		// the brand checks could be moved into the individual methods.
-		if ( $this->container->plugin()->brand === 'hostgator' ) {
+		if ( $this->container->plugin()->id === 'hostgator' ) {
 			add_filter( 'yith_sales_panel_page', array( $this, 'get_panel_page' ) );
 			add_filter( 'yith_sales_main_panel_page', array( $this, 'get_main_panel_page' ) );
 			add_filter( 'yith_sales_main_app_id', array( $this, 'get_main_app_id' ) );


### PR DESCRIPTION
This file contains wondercart filters for hostgator.

Currently, it is checking for a brand of "Hostgator", but it's not matching. This update will change it to check the plugin->id value rather than plugin->brand. The id is specific to the plugin and these filters seem to be plugin related rather than brand related. For example, hostgator-latam would not load this content as the brand is different, but it is using the same plugin, so it should take less cases.

Eventually, we'll need to update this to include all brands. It wouldn't be a bad idea to add the bluehost defaults here too (even though they are in wondercart already), so we can change them if needed and have them in one place.