### PR TITLE
Release 1.3.13

### DIFF
--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => '9acdf365c2c0589df651');
+<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => '342c262e9a94ce889f05');

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "newfold-labs/wp-module-data",
-            "version": "2.4.11",
+            "version": "2.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-data.git",
-                "reference": "c244dd52e7e07bf0d890e51892e179c62f197bac"
+                "reference": "a21d4579037add8bb921426f8d41e15d13b81af3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/c244dd52e7e07bf0d890e51892e179c62f197bac",
-                "reference": "c244dd52e7e07bf0d890e51892e179c62f197bac",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/a21d4579037add8bb921426f8d41e15d13b81af3",
+                "reference": "a21d4579037add8bb921426f8d41e15d13b81af3",
                 "shasum": ""
             },
             "require": {
@@ -50,10 +50,10 @@
             ],
             "description": "Newfold Data Module",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.4.11",
+                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.4.13",
                 "issues": "https://github.com/newfold-labs/wp-module-data/issues"
             },
-            "time": "2023-11-13T19:54:44+00:00"
+            "time": "2023-11-29T18:53:24+00:00"
         },
         {
             "name": "newfold-labs/wp-module-installer",
@@ -99,16 +99,16 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",
-            "version": "0.0.7",
+            "version": "0.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding-data.git",
-                "reference": "dbebb068b86e8645d137abadba316331f715dc9f"
+                "reference": "3d9265b2c2e75978f9a4b6d430518817b2244301"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/dbebb068b86e8645d137abadba316331f715dc9f",
-                "reference": "dbebb068b86e8645d137abadba316331f715dc9f",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/3d9265b2c2e75978f9a4b6d430518817b2244301",
+                "reference": "3d9265b2c2e75978f9a4b6d430518817b2244301",
                 "shasum": ""
             },
             "require": {
@@ -133,10 +133,10 @@
             ],
             "description": "A non-toggleable module containing a standardized interface for interacting with Onboarding data.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/0.0.7",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/0.0.8",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding-data/issues"
             },
-            "time": "2023-11-17T09:04:51+00:00"
+            "time": "2023-11-29T09:37:19+00:00"
         },
         {
             "name": "wp-forge/wp-query-builder",
@@ -658,16 +658,16 @@
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.5.7",
+            "version": "1.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "c848241796da2abf65837d51dce1fae55a960149"
+                "reference": "560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/c848241796da2abf65837d51dce1fae55a960149",
-                "reference": "c848241796da2abf65837d51dce1fae55a960149",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a",
+                "reference": "560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a",
                 "shasum": ""
             },
             "require": {
@@ -716,9 +716,9 @@
                 "validator"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/composer",
+                "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/spdx-licenses/issues",
-                "source": "https://github.com/composer/spdx-licenses/tree/1.5.7"
+                "source": "https://github.com/composer/spdx-licenses/tree/1.5.8"
             },
             "funding": [
                 {
@@ -734,7 +734,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-23T07:37:50+00:00"
+            "time": "2023-11-20T07:44:33+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -4579,5 +4579,5 @@
     "platform-overrides": {
         "php": "7.0.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -83,6 +83,7 @@ class ECommerce {
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'register_assets' ) );
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'register_textdomains' ) );
 		add_action('wp_body_open', array( $this, 'regiester_site_preview' ));
+		add_action('before_woocommerce_init', array( $this,'hide_woocommerce_set_up') );
 
 		// Handle WonderCart Integrations
 		if ( is_plugin_active( 'wonder-cart/init.php' ) ) {
@@ -322,5 +323,16 @@ class ECommerce {
 		if($is_coming_soon){
 		echo "<div style='background-color: #e71616; padding: 0 16px;color:#ffffff;font-size:16px;text-align:center;font-weight: 590;'>" . esc_html__( 'Site Preview - This site is NOT LIVE, only admins can see this view.', 'wp-module-ecommerce' ) . "</div>";
 		}
+	}
+	public function hide_woocommerce_set_up() {
+		$hidden_list = get_option('woocommerce_task_list_hidden_lists', []);
+		if(! in_array("setup", $hidden_list)){
+			$woocommerce_list = array_merge(get_option('woocommerce_task_list_hidden_lists', []),array(
+				"setup" 
+			));
+			// $woocommerce_list = array("setup");
+			update_option('woocommerce_task_list_hidden_lists', $woocommerce_list);
+		}
+		
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newfold-labs/wp-module-ecommerce",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@newfold-labs/wp-module-ecommerce",
-      "version": "1.3.12",
+      "version": "1.3.13",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@faizaanceg/pandora": "^1.1.1",
@@ -72,11 +72,11 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -140,30 +140,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
-      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
-      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
+      "integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.5",
         "@babel/helper-compilation-targets": "^7.22.15",
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.3",
+        "@babel/helpers": "^7.23.5",
+        "@babel/parser": "^7.23.5",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.3",
-        "@babel/types": "^7.23.3",
+        "@babel/traverse": "^7.23.5",
+        "@babel/types": "^7.23.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -215,12 +215,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
-      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
+      "integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.3",
+        "@babel/types": "^7.23.5",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -279,17 +279,17 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.15.tgz",
-      "integrity": "sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.5.tgz",
+      "integrity": "sha512-QELlRWxSpgdwdJzSJn4WAhKC+hvw/AtHbbrIoncKHkhKKR/luAlKkgBDcri1EzWAo8f8VvYVryEHN4tax/V67A==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
-        "@babel/helper-member-expression-to-functions": "^7.22.15",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-member-expression-to-functions": "^7.23.0",
         "@babel/helper-optimise-call-expression": "^7.22.5",
-        "@babel/helper-replace-supers": "^7.22.9",
+        "@babel/helper-replace-supers": "^7.22.20",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
         "semver": "^6.3.1"
@@ -520,9 +520,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -536,9 +536,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -559,23 +559,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
-      "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.5.tgz",
+      "integrity": "sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0"
+        "@babel/traverse": "^7.23.5",
+        "@babel/types": "^7.23.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
@@ -642,9 +642,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
-      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
+      "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1006,9 +1006,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.3.tgz",
-      "integrity": "sha512-59GsVNavGxAXCDDbakWSMJhajASb4kBCqDjqJsv+p5nKdbz7istmZ3HrX3L2LuiI80+zsOADCvooqQH3qGCucQ==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.4.tgz",
+      "integrity": "sha512-efdkfPhHYTtn0G6n2ddrESE91fgXxjlqLsnUtPWnJs4a4mZIbUaK7ffqKIIUKXSHwcDvaCVX6GXkaJJFqtX7jw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.3.tgz",
-      "integrity": "sha512-QPZxHrThbQia7UdvfpaRRlq/J9ciz1J4go0k+lPBXbgaNeY7IQrBj/9ceWjvMMI07/ZBzHl/F0R/2K0qH7jCVw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.4.tgz",
+      "integrity": "sha512-0QqbP6B6HOh7/8iNR4CQU2Th/bbRtBp4KS9vcaZd1fZ0wSh5Fyssg0UCIHwxh+ka+pNDREbVLQnHCMHKZfPwfw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.3.tgz",
-      "integrity": "sha512-PENDVxdr7ZxKPyi5Ffc0LjXdnJyrJxyqF5T5YjlVg4a0VFfQHW0r8iAtRiDXkfHlu1wwcvdtnndGYIeJLSuRMQ==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.4.tgz",
+      "integrity": "sha512-nsWu/1M+ggti1SOALj3hfx5FXzAY06fwPJsUZD4/A5e1bWi46VUIWtD+kOX6/IdhXGsXBWllLFDSnqSCdUNydQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.22.15",
@@ -1104,9 +1104,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.3.tgz",
-      "integrity": "sha512-FGEQmugvAEu2QtgtU0uTASXevfLMFfBeVCIIdcQhn/uBQsMTjBajdnAtanQlOcuihWh10PZ7+HWvc7NtBwP74w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.5.tgz",
+      "integrity": "sha512-jvOTR4nicqYC9yzOHIhXG5emiFEOpappSJAl73SDSEDcybD+Puuze8Tnpb9p9qEyYup24tq891gkaygIFvWDqg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -1189,9 +1189,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.23.3.tgz",
-      "integrity": "sha512-vTG+cTGxPFou12Rj7ll+eD5yWeNl5/8xvQvF08y5Gv3v4mZQoyFf8/n9zg4q5vvCWt5jmgymfzMAldO7orBn7A==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.23.4.tgz",
+      "integrity": "sha512-V6jIbLhdJK86MaLh4Jpghi8ho5fGzt3imHOBu/x0jlBaPYqDoWz4RDXjmMOfnh+JWNaQleEAByZLV0QzBT4YQQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1221,9 +1221,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.23.3.tgz",
-      "integrity": "sha512-yCLhW34wpJWRdTxxWtFZASJisihrfyMOTOQexhVzA78jlU+dH7Dw+zQgcPepQ5F3C6bAIiblZZ+qBggJdHiBAg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.23.4.tgz",
+      "integrity": "sha512-GzuSBcKkx62dGzZI1WVgTWvkkz84FZO5TC5T8dl/Tht/rAla6Dg/Mz9Yhypg+ezVACf/rgDuQt3kbWEv7LdUDQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1269,9 +1269,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-json-strings": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.23.3.tgz",
-      "integrity": "sha512-H9Ej2OiISIZowZHaBwF0tsJOih1PftXJtE8EWqlEIwpc7LMTGq0rPOrywKLQ4nefzx8/HMR0D3JGXoMHYvhi0A==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.23.4.tgz",
+      "integrity": "sha512-81nTOqM1dMwZ/aRXQ59zVubN9wHGqk6UtqRK+/q+ciXmRy8fSolhGVvG09HHRGo4l6fr/c4ZhXUQH0uFW7PZbg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1300,9 +1300,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.23.3.tgz",
-      "integrity": "sha512-+pD5ZbxofyOygEp+zZAfujY2ShNCXRpDRIPOiBmTO693hhyOEteZgl876Xs9SAHPQpcV0vz8LvA/T+w8AzyX8A==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.23.4.tgz",
+      "integrity": "sha512-Mc/ALf1rmZTP4JKKEhUwiORU+vcfarFVLfcFiolKUo6sewoxSEgl36ak5t+4WamRsNr6nzjZXQjM35WsU+9vbg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1429,9 +1429,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.23.3.tgz",
-      "integrity": "sha512-xzg24Lnld4DYIdysyf07zJ1P+iIfJpxtVFOzX4g+bsJ3Ng5Le7rXx9KwqKzuyaUeRnt+I1EICwQITqc0E2PmpA==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.23.4.tgz",
+      "integrity": "sha512-jHE9EVVqHKAQx+VePv5LLGHjmHSJR76vawFPTdlxR/LVJPfOEGxREQwQfjuZEOPTwG92X3LINSh3M40Rv4zpVA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1445,9 +1445,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.23.3.tgz",
-      "integrity": "sha512-s9GO7fIBi/BLsZ0v3Rftr6Oe4t0ctJ8h4CCXfPoEJwmvAPMyNrfkOOJzm6b9PX9YXcCJWWQd/sBF/N26eBiMVw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.23.4.tgz",
+      "integrity": "sha512-mps6auzgwjRrwKEZA05cOwuDc9FAzoyFS4ZsG/8F43bTLf/TgkJg7QXOrPO1JO599iA3qgK9MXdMGOEC8O1h6Q==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1461,9 +1461,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.3.tgz",
-      "integrity": "sha512-VxHt0ANkDmu8TANdE9Kc0rndo/ccsmfe2Cx2y5sI4hu3AukHQ5wAu4cM7j3ba8B9548ijVyclBU+nuDQftZsog==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.4.tgz",
+      "integrity": "sha512-9x9K1YyeQVw0iOXJlIzwm8ltobIIv7j2iLyP2jIhEbqPRQ7ScNgwQufU2I0Gq11VjyG4gI4yMXt2VFags+1N3g==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.23.3",
@@ -1496,9 +1496,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.23.3.tgz",
-      "integrity": "sha512-LxYSb0iLjUamfm7f1D7GpiS4j0UAC8AOiehnsGAP8BEsIX8EOi3qV6bbctw8M7ZvLtcoZfZX5Z7rN9PlWk0m5A==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.23.4.tgz",
+      "integrity": "sha512-XIq8t0rJPHf6Wvmbn9nFxU6ao4c7WhghTR5WyV8SrJfUFzyxhCm4nhC+iAp3HFhbAKLfYpgzhJ6t4XCtVwqO5A==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1512,9 +1512,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.3.tgz",
-      "integrity": "sha512-zvL8vIfIUgMccIAK1lxjvNv572JHFJIKb4MWBz5OGdBQA0fB0Xluix5rmOby48exiJc987neOmP/m9Fnpkz3Tg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.4.tgz",
+      "integrity": "sha512-ZU8y5zWOfjM5vZ+asjgAPwDaBjJzgufjES89Rs4Lpq63O300R/kOz30WCLo6BxxX6QVEilwSlpClnG5cZaikTA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1560,9 +1560,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.23.3.tgz",
-      "integrity": "sha512-a5m2oLNFyje2e/rGKjVfAELTVI5mbA0FeZpBnkOWWV7eSmKQ+T/XW0Vf+29ScLzSxX+rnsarvU0oie/4m6hkxA==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.23.4.tgz",
+      "integrity": "sha512-9G3K1YqTq3F4Vt88Djx1UZ79PDyj+yKRnUy7cZGSMe+a7jkwD259uKKuUzQlPkGam7R+8RJwh5z4xO27fA1o2A==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -1623,16 +1623,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.15.tgz",
-      "integrity": "sha512-oKckg2eZFa8771O/5vi7XeTvmM6+O9cxZu+kanTU7tD4sin5nO/G8jGJhq8Hvt2Z0kUoEDRayuZLaUlYl8QuGA==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.23.4.tgz",
+      "integrity": "sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/plugin-syntax-jsx": "^7.22.5",
-        "@babel/types": "^7.22.15"
+        "@babel/plugin-syntax-jsx": "^7.23.3",
+        "@babel/types": "^7.23.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1704,9 +1704,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.3.tgz",
-      "integrity": "sha512-XcQ3X58CKBdBnnZpPaQjgVMePsXtSZzHoku70q9tUAQp02ggPQNM04BF3RvlW1GSM/McbSOQAzEK4MXbS7/JFg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.4.tgz",
+      "integrity": "sha512-ITwqpb6V4btwUG0YJR82o2QvmWrLgDnx/p2A3CTPYGaRgULkDiC0DRA2C4jlRB9uXGUEfaSS/IGHfVW+ohzYDw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.22.15",
@@ -1809,13 +1809,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.3.tgz",
-      "integrity": "sha512-ogV0yWnq38CFwH20l2Afz0dfKuZBx9o/Y2Rmh5vuSS0YD1hswgEgTfyTzuSrT2q9btmHRSqYoSfwFUVaC1M1Jw==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.5.tgz",
+      "integrity": "sha512-2fMkXEJkrmwgu2Bsv1Saxgj30IXZdJ+84lQcKKI7sm719oXs0BBw2ZENKdJdR1PjWndgLCEBNXJOri0fk7RYQA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-create-class-features-plugin": "^7.23.5",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/plugin-syntax-typescript": "^7.23.3"
       },
@@ -1890,15 +1890,15 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.3.tgz",
-      "integrity": "sha512-ovzGc2uuyNfNAs/jyjIGxS8arOHS5FENZaNn4rtE7UdKMMkqHCvboHfcuhWLZNX5cB44QfcGNWjaevxMzzMf+Q==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.5.tgz",
+      "integrity": "sha512-0d/uxVD6tFGWXGDSfyMD1p2otoaKmu6+GD+NfAx0tMaH+dxORnp7T9TaVQ6mKyya7iBtCIVxHjWT7MuzzM9z+A==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.23.3",
+        "@babel/compat-data": "^7.23.5",
         "@babel/helper-compilation-targets": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/helper-validator-option": "^7.22.15",
+        "@babel/helper-validator-option": "^7.23.5",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
         "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.3",
@@ -1922,25 +1922,25 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.23.3",
-        "@babel/plugin-transform-async-generator-functions": "^7.23.3",
+        "@babel/plugin-transform-async-generator-functions": "^7.23.4",
         "@babel/plugin-transform-async-to-generator": "^7.23.3",
         "@babel/plugin-transform-block-scoped-functions": "^7.23.3",
-        "@babel/plugin-transform-block-scoping": "^7.23.3",
+        "@babel/plugin-transform-block-scoping": "^7.23.4",
         "@babel/plugin-transform-class-properties": "^7.23.3",
-        "@babel/plugin-transform-class-static-block": "^7.23.3",
-        "@babel/plugin-transform-classes": "^7.23.3",
+        "@babel/plugin-transform-class-static-block": "^7.23.4",
+        "@babel/plugin-transform-classes": "^7.23.5",
         "@babel/plugin-transform-computed-properties": "^7.23.3",
         "@babel/plugin-transform-destructuring": "^7.23.3",
         "@babel/plugin-transform-dotall-regex": "^7.23.3",
         "@babel/plugin-transform-duplicate-keys": "^7.23.3",
-        "@babel/plugin-transform-dynamic-import": "^7.23.3",
+        "@babel/plugin-transform-dynamic-import": "^7.23.4",
         "@babel/plugin-transform-exponentiation-operator": "^7.23.3",
-        "@babel/plugin-transform-export-namespace-from": "^7.23.3",
+        "@babel/plugin-transform-export-namespace-from": "^7.23.4",
         "@babel/plugin-transform-for-of": "^7.23.3",
         "@babel/plugin-transform-function-name": "^7.23.3",
-        "@babel/plugin-transform-json-strings": "^7.23.3",
+        "@babel/plugin-transform-json-strings": "^7.23.4",
         "@babel/plugin-transform-literals": "^7.23.3",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.23.3",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.23.4",
         "@babel/plugin-transform-member-expression-literals": "^7.23.3",
         "@babel/plugin-transform-modules-amd": "^7.23.3",
         "@babel/plugin-transform-modules-commonjs": "^7.23.3",
@@ -1948,15 +1948,15 @@
         "@babel/plugin-transform-modules-umd": "^7.23.3",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
         "@babel/plugin-transform-new-target": "^7.23.3",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.23.3",
-        "@babel/plugin-transform-numeric-separator": "^7.23.3",
-        "@babel/plugin-transform-object-rest-spread": "^7.23.3",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.23.4",
+        "@babel/plugin-transform-numeric-separator": "^7.23.4",
+        "@babel/plugin-transform-object-rest-spread": "^7.23.4",
         "@babel/plugin-transform-object-super": "^7.23.3",
-        "@babel/plugin-transform-optional-catch-binding": "^7.23.3",
-        "@babel/plugin-transform-optional-chaining": "^7.23.3",
+        "@babel/plugin-transform-optional-catch-binding": "^7.23.4",
+        "@babel/plugin-transform-optional-chaining": "^7.23.4",
         "@babel/plugin-transform-parameters": "^7.23.3",
         "@babel/plugin-transform-private-methods": "^7.23.3",
-        "@babel/plugin-transform-private-property-in-object": "^7.23.3",
+        "@babel/plugin-transform-private-property-in-object": "^7.23.4",
         "@babel/plugin-transform-property-literals": "^7.23.3",
         "@babel/plugin-transform-regenerator": "^7.23.3",
         "@babel/plugin-transform-reserved-words": "^7.23.3",
@@ -2052,9 +2052,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
+      "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2077,19 +2077,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
-      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
+      "integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.5",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.3",
-        "@babel/types": "^7.23.3",
+        "@babel/parser": "^7.23.5",
+        "@babel/types": "^7.23.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -2098,11 +2098,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
-      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
+      "integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
@@ -2463,9 +2463,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
-      "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.54.0.tgz",
+      "integrity": "sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3049,22 +3049,22 @@
       }
     },
     "node_modules/@newfold-labs/js-utility-ui-analytics/node_modules/@wordpress/api-fetch": {
-      "version": "6.43.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.43.0.tgz",
-      "integrity": "sha512-DYtawNaOHDxgIl+B/E1oU+VMhFJJfy/oYR5e7+PFUX0t0yHhHuH8XaWKpZvpvo0Y/GOuJ2NkDcJDqSZXD2TFYw==",
+      "version": "6.44.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.44.0.tgz",
+      "integrity": "sha512-d8ouvBiKDFu67O9Y8MtlUR2YojCAjmLf0LuBKsSOS5r3MOiwte1tQwsLdzFmGYkdCK09mZhT3UVKdOOiAC3kKA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.46.0",
-        "@wordpress/url": "^3.47.0"
+        "@wordpress/i18n": "^4.47.0",
+        "@wordpress/url": "^3.48.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@newfold-labs/js-utility-ui-analytics/node_modules/@wordpress/url": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.47.0.tgz",
-      "integrity": "sha512-eDj7eDDYS8/UaUioulM54JkhmYvplvwW8+rbidR0fKZLr9zu3mfM7vrlwpIv9OK2RMenqEvu7Ij2gc5n/YEAcQ==",
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.48.0.tgz",
+      "integrity": "sha512-12bjIBBGcA5X8RPvUURLJZzpB60O5DI3WxQVIBBKPF4Mv8nUmgT4uemGzf5/ble8lqzJVntyEhEWKPOxEbUbJg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "remove-accents": "^0.5.0"
@@ -3088,9 +3088,9 @@
       }
     },
     "node_modules/@newfold/ui-component-library": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@newfold/ui-component-library/-/ui-component-library-1.0.0.tgz",
-      "integrity": "sha512-zEP2oe+WHu1VJ4B34tKb+8cOdSIefSZ5sappZHLJtA3DM+LhP4NHoVvLt34YYNdm9Zq1mL/M5PH9uqCbMQZFOg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@newfold/ui-component-library/-/ui-component-library-1.0.1.tgz",
+      "integrity": "sha512-p/nCSWcVNs7hOzUJNQXbyiQe82WAzUXbSENIvMX326FeLyETo0AtncqNUZJxABDIVQVQONu+19uRCAqCRvZBPQ==",
       "dependencies": {
         "@headlessui/react": "^1.7.8",
         "@heroicons/react": "^1.0.6",
@@ -3247,14 +3247,14 @@
       }
     },
     "node_modules/@replayio/cypress": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@replayio/cypress/-/cypress-1.7.2.tgz",
-      "integrity": "sha512-Ld1fiLAyblvaeZMojf5wvh5i9s/aDWG8lp5Q8uaCYgj3SipmQ1E1CQ2S2iMKDbJjLMhWp+OKLWyWT9vmH8EvDQ==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@replayio/cypress/-/cypress-1.7.6.tgz",
+      "integrity": "sha512-jWHh5Q2UcaGQ/ghe7RMJlR/vfpAW9995dohxIRTB/laywiB2Bfk/Y/D/ZR+0MYV1Kx8XsXkOQRYDCx1F2cp0Cw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@replayio/replay": "^0.19.1",
-        "@replayio/test-utils": "^1.3.2",
+        "@replayio/replay": "^0.19.4",
+        "@replayio/test-utils": "^1.3.6",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "semver": "^7.5.2",
@@ -3271,9 +3271,9 @@
       }
     },
     "node_modules/@replayio/replay": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@replayio/replay/-/replay-0.19.1.tgz",
-      "integrity": "sha512-7baMKu2sCAHdqiM6pvRf8RPWzTJzN6iTsqetB+zW/0Uo0BFqmXyTRRH4Q7FBxtRxLz/J5m9yOJIXMYnOveJqEQ==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@replayio/replay/-/replay-0.19.4.tgz",
+      "integrity": "sha512-T8XlT4jKVoQgPGNieYz3C++IowUVXWjqTMWNMcPrv0368h7MTTKrvnKCTTNmeDFXW819AeCRcCi+Xvgra2OzmQ==",
       "dev": true,
       "dependencies": {
         "@replayio/sourcemap-upload": "^1.1.1",
@@ -3329,12 +3329,12 @@
       }
     },
     "node_modules/@replayio/test-utils": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@replayio/test-utils/-/test-utils-1.3.2.tgz",
-      "integrity": "sha512-xt9KGLSm57JWYeOoollr8tTZ4GomheZaJz4T12fDFqMNjtI9MOzJDE0/aY63ORsMV83QLiToZ0/mT8xWY6VKyA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@replayio/test-utils/-/test-utils-1.3.6.tgz",
+      "integrity": "sha512-GBcMwLyqqPkODtgyyy5/j3BPqcUqquHgAszbUlbCwWvgBc1TfUgNg9yrBCa5cR5tcdLE9m/h1taxEAqs2MKO8Q==",
       "dev": true,
       "dependencies": {
-        "@replayio/replay": "^0.19.1",
+        "@replayio/replay": "^0.19.4",
         "debug": "^4.3.4",
         "node-fetch": "^2.6.7",
         "uuid": "^8.3.2"
@@ -3766,9 +3766,9 @@
       "dev": true
     },
     "node_modules/@types/babel__core": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.4.tgz",
-      "integrity": "sha512-mLnSC22IC4vcWiuObSRjrLd9XcBTGf59vUSoq2jkQDJ/QQ8PMI9rSuzE+aEV8karUMbskw07bKYoUJCKTUaygg==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -3847,9 +3847,9 @@
       }
     },
     "node_modules/@types/connect-history-api-fallback": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.3.tgz",
-      "integrity": "sha512-6mfQ6iNvhSKCZJoY6sIG3m0pKkdUcweVNOLuBBKvoWGzl2yRxOJcYOTRyLKt3nxXvBLJWa6QkW//tgbIwJehmA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
+      "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
       "dev": true,
       "dependencies": {
         "@types/express-serve-static-core": "*",
@@ -3857,9 +3857,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.44.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.7.tgz",
-      "integrity": "sha512-f5ORu2hcBbKei97U73mf+l9t4zTGl74IqZ0GQk4oVea/VS8tQZYkUveSYojk+frraAVYId0V2WC9O4PTNru2FQ==",
+      "version": "8.44.8",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.8.tgz",
+      "integrity": "sha512-4K8GavROwhrYl2QXDXm0Rv9epkA8GBFu0EI+XrrnnuCl7u8CWBRusX7fXJfanhZTDWSAL24gDI/UqXyUM0Injw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*",
@@ -4021,23 +4021,23 @@
       "dev": true
     },
     "node_modules/@types/mousetrap": {
-      "version": "1.6.14",
-      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.14.tgz",
-      "integrity": "sha512-aY69yje/bZllr99dbIcQwB365YDH/9myLodpxQ8cQZhGfavICi389aRvwa5LUoW+gTpcZKHjVI/sc0dDjUqVuw=="
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
+      "integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw=="
     },
     "node_modules/@types/node": {
-      "version": "20.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.1.tgz",
-      "integrity": "sha512-HhmzZh5LSJNS5O8jQKpJ/3ZcrrlG6L70hpGqMIAoM9YVD0YBRNWYsfwcXq8VnSjlNpCpgLzMXdiPo+dxcvSmiA==",
+      "version": "20.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.1.tgz",
+      "integrity": "sha512-T2qwhjWwGH81vUEx4EXmBKsTJRXFXNZTL4v0gi01+zyBmCwzE6TyHszqX01m+QHTEq+EZNo13NeJIdEqf+Myrg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/node-forge": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.9.tgz",
-      "integrity": "sha512-meK88cx/sTalPSLSoCzkiUB4VPIFHmxtXm5FaaqRDqBX2i/Sy8bJ4odsan0b20RBjPh06dAQ+OTTdnyQyhJZyQ==",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.10.tgz",
+      "integrity": "sha512-y6PJDYN4xYBxwd22l+OVH35N+1fCYWiuC3aiP2SlXVE6Lo7SS+rSx9r89hLxrP4pn6n1lBGhHJ12pj3F3Mpttw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -4055,9 +4055,9 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.10",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.10.tgz",
-      "integrity": "sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A=="
+      "version": "15.7.11",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.10",
@@ -4072,9 +4072,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "16.14.51",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.51.tgz",
-      "integrity": "sha512-4T/wsDXStA5OUGTj6w2INze3ZCz22IwQiWcApgqqNRU2A6vNUIPXpNkjAMUFxx6diYPVkvz+d7gEtU7AZ+0Xqg==",
+      "version": "16.14.52",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.52.tgz",
+      "integrity": "sha512-4+ZN73hgRW3Gang3QMqWjrqPPkf+lWZYiyG4uXtUbpd+7eiBDw6Gemila6rXDd8DorADupTiIERL6Mb5BQTF2w==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4082,9 +4082,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "16.9.22",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.22.tgz",
-      "integrity": "sha512-x7T/NHsYiKfbIwZDzBTThTF3a3UPNLanOY4wbEe4Hy44hf0tWIZTu8VZJTkB/FKcr4cbfDq0E7y3jSLJh4cpow==",
+      "version": "16.9.24",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.24.tgz",
+      "integrity": "sha512-Gcmq2JTDheyWn/1eteqyzzWKSqDjYU6KYsIvH7thb7CR5OYInAWOX+7WnKf6PaU/cbdOc4szJItcDEJO7UGmfA==",
       "dependencies": {
         "@types/react": "^16"
       }
@@ -4110,14 +4110,14 @@
       "dev": true
     },
     "node_modules/@types/scheduler": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.6.tgz",
-      "integrity": "sha512-Vlktnchmkylvc9SnwwwozTv04L/e1NykF5vgoQ0XTmI8DD+wxfjQuHuvHS3p0r2jz2x2ghPs2h1FVeDirIteWA=="
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/semver": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
-      "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
     },
     "node_modules/@types/send": {
@@ -4157,9 +4157,9 @@
       "dev": true
     },
     "node_modules/@types/sizzle": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.6.tgz",
-      "integrity": "sha512-m04Om5Gz6kbjUwAQ7XJJQ30OdEFsSmAVsvn4NYwcTRyMVpKKa1aPuESw1n2CxS5fYkOQv3nHgDKeNa8e76fUkw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
+      "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
       "dev": true
     },
     "node_modules/@types/sockjs": {
@@ -4172,9 +4172,9 @@
       }
     },
     "node_modules/@types/source-list-map": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.5.tgz",
-      "integrity": "sha512-cHBTLeIGIREJx839cDfMLKWao+FaJOlaPz4mnFHXUzShS8sXhzw6irhvIpYvp28TbTmTeAt3v+QgHMANsGbQtA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.6.tgz",
+      "integrity": "sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -4184,9 +4184,9 @@
       "dev": true
     },
     "node_modules/@types/tapable": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.11.tgz",
-      "integrity": "sha512-R3ltemSqZ/TKOBeyy+GBfZCLX3AYpxqarIbUMNe7+lxdazJp4iWLFpmjgBeZoRiKrWNImer1oWOlG2sDR6vGaw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.12.tgz",
+      "integrity": "sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==",
       "dev": true
     },
     "node_modules/@types/tough-cookie": {
@@ -4214,9 +4214,9 @@
       }
     },
     "node_modules/@types/webpack": {
-      "version": "4.41.36",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.36.tgz",
-      "integrity": "sha512-pF+DVW1pMLmgsPXqJr5QimdxIzOhe8oGKB98gdqAm0egKBy1lOLD5mRxbYboMQRkpYcG7BYcpqYblpKyvE7vhQ==",
+      "version": "4.41.38",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.38.tgz",
+      "integrity": "sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -4248,18 +4248,18 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
-      "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.31",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.31.tgz",
-      "integrity": "sha512-bocYSx4DI8TmdlvxqGpVNXOgCNR1Jj0gNPhhAY+iz1rgKDAaYrAYdFYnhDV1IFuiuVc9HkOwyDcFxaTElF3/wg==",
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -4742,9 +4742,9 @@
       }
     },
     "node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.29.0.tgz",
-      "integrity": "sha512-VPAn1iVZae1sQ6QaiMKbp3AzFPbhBl6YQeDr3AKpj24GTiUmsho6WgxijzyhBEBX5xPHVCahhQ8mjiZ5Ql6FwA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.30.0.tgz",
+      "integrity": "sha512-UKkyFmEYk1UTO0ZPun6Kw5dNflTEDpDK/6RxAqxbVrsIWUVSkVahwBnqfS0v5LuvVU8y+5vJSR/WjlnKEmS3Sg==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -4754,9 +4754,9 @@
       }
     },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "7.30.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.30.0.tgz",
-      "integrity": "sha512-O/IA8Jvh6MzlTyeo0As2chhZ2w6WdvMYSjjTDDC66SkbnUxUf4jWqehncHGrtQLoQJfwsCUnyWSH4ePb/j+kIw==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.31.0.tgz",
+      "integrity": "sha512-LAiTOlolFvKW6xmL6qRkdbPG09LPwAsmDepz4zWrFXJZHSImDeO2QXHecF1GnFyzLLKr1myHR5MbN3K5MSzpqQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -4765,9 +4765,9 @@
         "@babel/preset-env": "^7.16.0",
         "@babel/preset-typescript": "^7.16.0",
         "@babel/runtime": "^7.16.0",
-        "@wordpress/babel-plugin-import-jsx-pragma": "^4.29.0",
-        "@wordpress/browserslist-config": "^5.29.0",
-        "@wordpress/warning": "^2.46.0",
+        "@wordpress/babel-plugin-import-jsx-pragma": "^4.30.0",
+        "@wordpress/browserslist-config": "^5.30.0",
+        "@wordpress/warning": "^2.47.0",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
         "react": "^18.2.0"
@@ -4789,15 +4789,15 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.37.0.tgz",
-      "integrity": "sha512-HxYlZHHpq0XDd+/ixTjB0g2smw8NIhal0gZgKJsQSPra/TN5Swjt0e3QwW3MBGZKWhV9poNmsBGNZonVCe9bSA==",
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.38.0.tgz",
+      "integrity": "sha512-w491MMHfoCHdWibyTAcmGWvXwNMptslFQOU+jQ5DVeDIgDux1KLo/7oZ41CCHwqYayrCf60BC9+JopDXqq1H+g==",
       "dev": true
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.29.0.tgz",
-      "integrity": "sha512-sVDgPWcI3wdKd3cIvgf/NLO7HtEkwyV4bWuSztzoemNMGQW17BhH2Blx46HnJFXm9ooYw4SpAOyioHTkuT+JFg==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.30.0.tgz",
+      "integrity": "sha512-HFgLCkvvxba+j7/qNjVn1od38tvMm1xVlIJBR+zukkTvvLu/AkdelWKAQpvAoFAXMaZJ7239VxDVBYbVolf6FQ==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -4894,18 +4894,18 @@
       }
     },
     "node_modules/@wordpress/data": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.16.0.tgz",
-      "integrity": "sha512-FEfHR5wlbtqssSVzey45Yq9+sFaFxiKZrY6MInkOVY7B/GtdSDpKDioDdTgmHKOnyaal4l1KHAE0bVEoMLfaFQ==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.17.0.tgz",
+      "integrity": "sha512-0FfNL4mHMkX8cBbGAjP8EJ/RGOvf/74qyhBXiLEGUz6swhW6RFrSPm7Dkqe5cMRqXDGoJn15OsOFIuLRllwVoQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.23.0",
-        "@wordpress/deprecated": "^3.46.0",
-        "@wordpress/element": "^5.23.0",
-        "@wordpress/is-shallow-equal": "^4.46.0",
-        "@wordpress/priority-queue": "^2.46.0",
-        "@wordpress/private-apis": "^0.28.0",
-        "@wordpress/redux-routine": "^4.46.0",
+        "@wordpress/compose": "^6.24.0",
+        "@wordpress/deprecated": "^3.47.0",
+        "@wordpress/element": "^5.24.0",
+        "@wordpress/is-shallow-equal": "^4.47.0",
+        "@wordpress/priority-queue": "^2.47.0",
+        "@wordpress/private-apis": "^0.29.0",
+        "@wordpress/redux-routine": "^4.47.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -4922,9 +4922,9 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@types/react": {
-      "version": "18.2.37",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.37.tgz",
-      "integrity": "sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==",
+      "version": "18.2.39",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.39.tgz",
+      "integrity": "sha512-Oiw+ppED6IremMInLV4HXGbfbG6GyziY3kqAwJYOR0PNbkYDmLWQA3a95EhdSmamsvbkJN96ZNN+YD+fGjzSBA==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4932,27 +4932,27 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@types/react-dom": {
-      "version": "18.2.15",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.15.tgz",
-      "integrity": "sha512-HWMdW+7r7MR5+PZqJF6YFNSCtjz1T0dsvo/f1BV6HkV+6erD/nA7wd9NM00KVG83zf2nJ7uATPO9ttdIPvi3gg==",
+      "version": "18.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz",
+      "integrity": "sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==",
       "dependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/compose": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.23.0.tgz",
-      "integrity": "sha512-MMWwYkbmA4IkdZQ/p3BMvgD9MvCGK2lJd8PjnftDw6NjRteXyA6CQjP1h+/mTlNJvHytqRu2cNPey0V0mnRx6A==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.24.0.tgz",
+      "integrity": "sha512-aO0HWi12Y7Do5hyGEOXcRtRTIn7P/t4RrHYMTsHvufCrt6ZCLKvY2vBEaDA8XnWFQZ/Tzo4fBAnxAAxDt1DtEw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^3.46.0",
-        "@wordpress/dom": "^3.46.0",
-        "@wordpress/element": "^5.23.0",
-        "@wordpress/is-shallow-equal": "^4.46.0",
-        "@wordpress/keycodes": "^3.46.0",
-        "@wordpress/priority-queue": "^2.46.0",
-        "@wordpress/undo-manager": "^0.6.0",
+        "@wordpress/deprecated": "^3.47.0",
+        "@wordpress/dom": "^3.47.0",
+        "@wordpress/element": "^5.24.0",
+        "@wordpress/is-shallow-equal": "^4.47.0",
+        "@wordpress/keycodes": "^3.47.0",
+        "@wordpress/priority-queue": "^2.47.0",
+        "@wordpress/undo-manager": "^0.7.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.8",
         "mousetrap": "^1.6.5",
@@ -4966,38 +4966,38 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/deprecated": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.46.0.tgz",
-      "integrity": "sha512-i7stkwWr9vUc2A9ILb0qIUfqtyjaG9yNbqRcfWDjqhOn6R4Drm4edwdpZKdYHSTiiH2qPCWZGTc6KVZm5wc9/Q==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.47.0.tgz",
+      "integrity": "sha512-Vq4h6LHGPUc/pqmLOANcPpiMrOVoTeZRDvKxE+ioR9ldEFo+uquMKrEmJZxXVXl0GZdMKQ4jGKx34z8S8VRwQw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.46.0"
+        "@wordpress/hooks": "^3.47.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/dom": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.46.0.tgz",
-      "integrity": "sha512-NiGBTpE7lzTAjkxw5HVp3EzyMxZA378/yed0id0krvEId4prmbIJWRwSNC+Yvn0nhuHczIl4wj9T9zYpksAcUg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.47.0.tgz",
+      "integrity": "sha512-SY6wfAc4yrXYil8fm/uyeKQnPjGuc0G9Q1/5pUKO6dssst8fClsrxy+hXNl0FYFGWnAZBqg5ccrwYydrFt5k/g==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^3.46.0"
+        "@wordpress/deprecated": "^3.47.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/element": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.23.0.tgz",
-      "integrity": "sha512-6c1EG8UJDzJGX6yWJGIi78bgomWJ6rSkMRR9d0UBis9bm9YFBJDydsD9bNx6XItrMEXR7yykXblfGY2YUK3SAA==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.24.0.tgz",
+      "integrity": "sha512-El1E5jlZitrDouvde0dUF2yVRiPsxPnjxB9TU43EhahQ9eT8pwfUaH3I4NT8kUj2LD76WwU8fN7CEmBNBW+ofA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@types/react": "^18.0.21",
         "@types/react-dom": "^18.0.6",
-        "@wordpress/escape-html": "^2.46.0",
+        "@wordpress/escape-html": "^2.47.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.2.0",
@@ -5008,9 +5008,9 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/escape-html": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.46.0.tgz",
-      "integrity": "sha512-sPjBUMTSqjDF1niqb6NnKim8Ju7zWVlgZoifO3cC+4DGZcRsKF78eTeuEojQJN7h/FHCjpKX3dvnr+ihv7syEQ==",
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.47.0.tgz",
+      "integrity": "sha512-bBGcTE5chneQJ3yETJyT2suyVtEJNfOiMVBV5qm606TyEzIDm18Sw2mPfOagiB1nOwDkAVfpSVD2NeGpit2alA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -5019,9 +5019,9 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/hooks": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.46.0.tgz",
-      "integrity": "sha512-TTYNZwMZeATpkWmvAoShP43UONd/WPNTtsy1czMSyiqPzFhzGJbKD75CdJtPp5DqIAiuWQEuDmcxRAPcZ/1Qgw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.47.0.tgz",
+      "integrity": "sha512-a0mZ+lSUBrmacJGXDnFTaz1O47sQgTCZi3LrY445WNc7cmiSlscTfeBxrUXaTF0ninzHJnE7evCIeKLbQC3dLQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -5030,9 +5030,9 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/is-shallow-equal": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.46.0.tgz",
-      "integrity": "sha512-1K5RTTi99ozF9vPKxoVl+RR6mSYy64DKYnijACDN9Sigzbe6OWeL6ky47r09G0JtDnRpzA0itIfFcV8iRNzpvA==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.47.0.tgz",
+      "integrity": "sha512-mfrw/GXtCzm5jciuXumabfJhJLzGU0EpGgXU9tDHw6CwDrtUMcM05qrvrXFk4IlE2hYFwuTkWryValMt3FFdoQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -5041,12 +5041,12 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/keycodes": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.46.0.tgz",
-      "integrity": "sha512-08ubCD321T85BZBUQuco2/vwIC5Pfzbw4CY7E2xR3rGzX3vb7SjDbKIqKeJL/UfYSmZF9GY+KaspSa1ywFtWiA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.47.0.tgz",
+      "integrity": "sha512-dmYpqCWUoCM290YA5ApES9nqz/0D1JngIlZtel+BvELf8fj/jctdsT5wDB7dVdvZCuyr5SF+1Od00DYbMbb5oA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.46.0",
+        "@wordpress/i18n": "^4.47.0",
         "change-case": "^4.1.2"
       },
       "engines": {
@@ -5054,9 +5054,9 @@
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/priority-queue": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.46.0.tgz",
-      "integrity": "sha512-ElNF4ONApHwwkEvP3Ta6Wly2RCljXLZpfyahOziq3rlK8gaeU82qRt13KBE85Djz+90yHSyDlX9YpmJebV9oPw==",
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.47.0.tgz",
+      "integrity": "sha512-ZA6BDYkEC3mY1UrEXYnihdb0GoJooxZ9ADPEDEnqY88EuUT8/eeIDOge7OzgatDa9ivzV8TP3Fs4C/mHg/s6dQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "requestidlecallback": "^0.3.0"
@@ -5107,12 +5107,12 @@
       }
     },
     "node_modules/@wordpress/date": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.46.0.tgz",
-      "integrity": "sha512-IsbAXOVYJfSVISGppERnZMWVvvCo07bjSXSKhbd6CDgzTFDPCyUrOmv8tcMUdHw7a4jbL0w/KRMqdhN/C8A0JQ==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.47.0.tgz",
+      "integrity": "sha512-HIruX+wMaQWKYLCFIu6JeEEoqRYkhpL4cWfZ1lJG78wNsgq3vRiHzXQaXHcbmJQCq0PZOxtmeSzldPiUMFVNpg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^3.46.0",
+        "@wordpress/deprecated": "^3.47.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -5121,21 +5121,21 @@
       }
     },
     "node_modules/@wordpress/date/node_modules/@wordpress/deprecated": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.46.0.tgz",
-      "integrity": "sha512-i7stkwWr9vUc2A9ILb0qIUfqtyjaG9yNbqRcfWDjqhOn6R4Drm4edwdpZKdYHSTiiH2qPCWZGTc6KVZm5wc9/Q==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.47.0.tgz",
+      "integrity": "sha512-Vq4h6LHGPUc/pqmLOANcPpiMrOVoTeZRDvKxE+ioR9ldEFo+uquMKrEmJZxXVXl0GZdMKQ4jGKx34z8S8VRwQw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.46.0"
+        "@wordpress/hooks": "^3.47.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@wordpress/date/node_modules/@wordpress/hooks": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.46.0.tgz",
-      "integrity": "sha512-TTYNZwMZeATpkWmvAoShP43UONd/WPNTtsy1czMSyiqPzFhzGJbKD75CdJtPp5DqIAiuWQEuDmcxRAPcZ/1Qgw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.47.0.tgz",
+      "integrity": "sha512-a0mZ+lSUBrmacJGXDnFTaz1O47sQgTCZi3LrY445WNc7cmiSlscTfeBxrUXaTF0ninzHJnE7evCIeKLbQC3dLQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -5144,9 +5144,9 @@
       }
     },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.29.0.tgz",
-      "integrity": "sha512-cYvTkjDvxpZSEjM1RRNciK/7W+RXC+qXXzbdRyGhkE0AzIspA7UAV3NoEyjtbL2V2wNJmBmsZKJf0wuYandDQA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.30.0.tgz",
+      "integrity": "sha512-Z3AcceaoHFvJdRNVp8rf6EI+rxK0gUMGMfcXYZPAoaDhP6Gt0bsbVMP5zQH2EYl7JHsbRZIQmMqd2fG5E/VjSQ==",
       "dev": true,
       "dependencies": {
         "json2php": "^0.0.7",
@@ -5178,9 +5178,9 @@
       }
     },
     "node_modules/@wordpress/dom-ready": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.46.0.tgz",
-      "integrity": "sha512-Xq/TPuOZk1DjBzuo4fPj226Lo8uoKk0v1Tydnb263gRmAniSXdwEyrLPMbo8DOAqEUPI9ZRbqomJo/mBR2V8TA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.47.0.tgz",
+      "integrity": "sha512-VsqaTQJ5Z7Qa3Doi5qk4LMnW0K78JEKLYRcg3ohapgBrQ2tKTS67oWgJx2VgWz8ky6j9UosecSISP3zJHXfEeA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0"
@@ -5204,9 +5204,9 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.12.0.tgz",
-      "integrity": "sha512-AP4rvv9oEqNtAk1o+V/sDeSDuBnTrbAc1nGp2Q8KMgaxhNSnMB4gn5K6zggG5HF0GPWbR5YaFkID+2FvT0DPIw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.13.0.tgz",
+      "integrity": "sha512-rtrrBO22DnbLsdBlsGqlMQrjz1dZfbwGnxyKev+gFd1rSfmLs+1F8L89RHOx9vsGPixl5uRwoU/qgYo7Hf1NVQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -5312,12 +5312,12 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.46.0.tgz",
-      "integrity": "sha512-5/61hd50KkqGgoQpf66DDft6sMTKfeGVdmZOt42GWymylxFSmbZLLnR8YafECQrmia/TdwIco5I4n0hIikYbNQ==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.47.0.tgz",
+      "integrity": "sha512-7qOeSChhI8drcnKAbpM2yP2HSWRR0U8xvww3Febd3kGhMKAUp8AMpjyC4rWucak4+Eg1HFfahurCmBt3FxgbYQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.46.0",
+        "@wordpress/hooks": "^3.47.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "sprintf-js": "^1.1.1",
@@ -5331,9 +5331,9 @@
       }
     },
     "node_modules/@wordpress/i18n/node_modules/@wordpress/hooks": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.46.0.tgz",
-      "integrity": "sha512-TTYNZwMZeATpkWmvAoShP43UONd/WPNTtsy1czMSyiqPzFhzGJbKD75CdJtPp5DqIAiuWQEuDmcxRAPcZ/1Qgw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.47.0.tgz",
+      "integrity": "sha512-a0mZ+lSUBrmacJGXDnFTaz1O47sQgTCZi3LrY445WNc7cmiSlscTfeBxrUXaTF0ninzHJnE7evCIeKLbQC3dLQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -5355,9 +5355,9 @@
       }
     },
     "node_modules/@wordpress/jest-console": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.17.0.tgz",
-      "integrity": "sha512-i1r0fGEZforoB1C8QuSfDDYwMycAJ/MqkEvhqWNLwcJy/JFYGWiKhkzhKfQ7aMUuwtrEJMb+41AOxelT565bDw==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.18.0.tgz",
+      "integrity": "sha512-OjPGbU1HgjLVNCLW9ROmdkw/qhpFL6Svlfv1aUVBrq5z1nJ7SrjRMeBSq4LJloOhTasSV9z7w4mhHJkMkfolJg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
@@ -5371,12 +5371,12 @@
       }
     },
     "node_modules/@wordpress/jest-preset-default": {
-      "version": "11.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.17.0.tgz",
-      "integrity": "sha512-Z1KAr9ViDLFiVAYsRkyAAwLBzxu6MTv1dAZpHhyZhYfxTNdTOnnHbNGHpsfv5OlT5xHxptkrESLP8klU2/kw4A==",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.18.0.tgz",
+      "integrity": "sha512-qwcDXfKkdBJnnsQAa0qkBsg94usGQCD914pWNeBg997qy/6zmVYVXpPjXoJXaC/lYbEIRAWGfry1RSiM6ZoC9g==",
       "dev": true,
       "dependencies": {
-        "@wordpress/jest-console": "^7.17.0",
+        "@wordpress/jest-console": "^7.18.0",
         "babel-jest": "^29.6.2"
       },
       "engines": {
@@ -5415,9 +5415,9 @@
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.31.0.tgz",
-      "integrity": "sha512-Y/MxST3sK/En6ZAChlyq5A7qtII9/1MLqk6o75yWPIDn1ew40V7iPBDkFKE3uMEPw1RW8rJ9WSQxNpcN+4k+Zg==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.32.0.tgz",
+      "integrity": "sha512-qyEnU9FoWpaa67pufu9fNmTCikiYhdKc4R01ffO+xX7wyJXMo0Z6EJog6ajU9E2+YL86AmAX+sO1CHuXcsxdbw==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -5427,12 +5427,12 @@
       }
     },
     "node_modules/@wordpress/postcss-plugins-preset": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.30.0.tgz",
-      "integrity": "sha512-b/APWKhvocBrs+IHJNe7BOfFmvyRmOZEHEXvwPZy2iGIC95tA5p2/7h3/iSwUGNUcyGObqwd90Htfit9oIdQJA==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.31.0.tgz",
+      "integrity": "sha512-B6bHsCKxt25nkvWfIJH3l7kENKS20mpsiRIl5+CEES6kKfBwg4IPx+JyA/RPLFQcIQNtIYFft22p5bgT4VZcEg==",
       "dev": true,
       "dependencies": {
-        "@wordpress/base-styles": "^4.37.0",
+        "@wordpress/base-styles": "^4.38.0",
         "autoprefixer": "^10.2.5"
       },
       "engines": {
@@ -5463,9 +5463,9 @@
       }
     },
     "node_modules/@wordpress/private-apis": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.28.0.tgz",
-      "integrity": "sha512-OAwLJfNIkSV2e77T7sXaGWtrbYuzhpusL0ufaR0hux6HfavHDmFuCjyyk3kUdq/GY6bFWDrWIvOTAkmVLYXdYg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.29.0.tgz",
+      "integrity": "sha512-8t4au9+IXXgJlxxOuYVYi8PKp0uWajNYILNfqCLB65jQEClzGNMQhU6MeJ9+kHN3gdOltMk7UzG28X+FTDlmkQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -5474,9 +5474,9 @@
       }
     },
     "node_modules/@wordpress/redux-routine": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.46.0.tgz",
-      "integrity": "sha512-gvyCIp5zh9Nxj3+H6tD6+DrXal7ER68yuvWgWe6+XRWG0D/MhBog6xe1TCJ6Ec5tFcL30cEEy33YPxCiNnPtjA==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.47.0.tgz",
+      "integrity": "sha512-MK9evE2Tn3wVTJhSyAPgIVzMWRd5M9Bjfn4n1in1fbmrYN7qnFYdP4VUJwwYlKRDFpJUxC/4iyREBOryoxKDZw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "is-plain-object": "^5.0.0",
@@ -5625,9 +5625,9 @@
       }
     },
     "node_modules/@wordpress/stylelint-config": {
-      "version": "21.29.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.29.0.tgz",
-      "integrity": "sha512-8VetLM5CTg8iLgodgpY4x132Yf4gPWMMffqfAG8HFwwvVQxm0mjl/dNtj6RBrxemdTi7dHr1jnZvqU+XxQlHXQ==",
+      "version": "21.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.30.0.tgz",
+      "integrity": "sha512-PlvXzYgjn7OUaVTy2bahSr6oL/eu1OdRWxrZfGVNxF4jRswND/ThqOEHIzxETNGTe0ggZOyY+40St4Swlo1zZQ==",
       "dev": true,
       "dependencies": {
         "stylelint-config-recommended": "^6.0.0",
@@ -5641,21 +5641,21 @@
       }
     },
     "node_modules/@wordpress/undo-manager": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.6.0.tgz",
-      "integrity": "sha512-u/oW1LAx0yANHzFHz/H1Tnopa7r/8q1D/bV2fescjQ947LLOpaImh7hlLn6ryEt8qCj2YSL9Ry2dDE2R/U1gQQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.7.0.tgz",
+      "integrity": "sha512-WhMKX/ETGUJr2GkaPgGwFF8gTU/PgikfvE2b2ZDjUglxIPYnujBa9S6w+kQPzwGniGJutHL1DFK+TmAaxoci9A==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^4.46.0"
+        "@wordpress/is-shallow-equal": "^4.47.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@wordpress/undo-manager/node_modules/@wordpress/is-shallow-equal": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.46.0.tgz",
-      "integrity": "sha512-1K5RTTi99ozF9vPKxoVl+RR6mSYy64DKYnijACDN9Sigzbe6OWeL6ky47r09G0JtDnRpzA0itIfFcV8iRNzpvA==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.47.0.tgz",
+      "integrity": "sha512-mfrw/GXtCzm5jciuXumabfJhJLzGU0EpGgXU9tDHw6CwDrtUMcM05qrvrXFk4IlE2hYFwuTkWryValMt3FFdoQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -5676,9 +5676,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.46.0.tgz",
-      "integrity": "sha512-oyUNmDz64nF8vnS9LaobXMIx6K5w+XhAtvo3Cjv3kCVIuWFwpxoeMus3pUo1A7v2H9zcW+E87zwEuqsLPYjNfQ==",
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.47.0.tgz",
+      "integrity": "sha512-lmpLNI8Si7HrSY0LBBtp7Z6NzAkh1y7yeJI0LZw17EsJ0MM5FSXqXJRrNY7L4tM8G/vv3OacUw1mRAZX7bzBRQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -5700,6 +5700,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
       "dev": true
     },
     "node_modules/accepts": {
@@ -7033,9 +7034,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001563",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001563.tgz",
-      "integrity": "sha512-na2WUmOxnwIZtwnFI2CZ/3er0wdNzU7hN+cPYz/z2ajHThnkWjNBOpEPP4n+4r2WPM847JaMotaJE3bnfzjyKw==",
+      "version": "1.0.30001565",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
+      "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
       "dev": true,
       "funding": [
         {
@@ -7297,9 +7298,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
-      "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -7799,9 +7800,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.2.tgz",
-      "integrity": "sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.3.tgz",
+      "integrity": "sha512-lo0kOocUlLKmm6kv/FswQL8zbkH7mVsLJ/FULClOhv8WRVmKLVcs6XPNQAzstfeJTCHMyButEwG+z1kHxHoDZw==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -7810,9 +7811,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.2.tgz",
-      "integrity": "sha512-axfo+wxFVxnqf8RvxTzoAlzW4gRoacrHeoFlc9n0x50+7BEyZL/Rt3hicaED1/CEd7I6tPCPVUYcJwCMO5XUYw==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.3.tgz",
+      "integrity": "sha512-cNzGqFsh3Ot+529GIXacjTJ7kegdt5fPXxCBVS1G0iaZpuo/tBz399ymceLJveQhFFZ8qThHiP3fzuoQjKN2ow==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.22.1"
@@ -7823,9 +7824,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.33.2.tgz",
-      "integrity": "sha512-a8zeCdyVk7uF2elKIGz67AjcXOxjRbwOLz8SbklEso1V+2DoW4OkAMZN9S9GBgvZIaqQi/OemFX4OiSoQEmg1Q==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.33.3.tgz",
+      "integrity": "sha512-taJ00IDOP+XYQEA2dAe4ESkmHt1fL8wzYDo3mRWQey8uO9UojlBFMneA65kMyxfYP7106c6LzWaq7/haDT6BCQ==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -8194,9 +8195,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.5.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.5.1.tgz",
-      "integrity": "sha512-yqLViT0D/lPI8Kkm7ciF/x/DCK/H/DnogdGyiTnQgX4OVR2aM30PtK+kvklTOD1u3TuItiD9wUQAF8EYWtyZug==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.0.tgz",
+      "integrity": "sha512-quIsnFmtj4dBUEJYU4OH0H12bABJpSujvWexC24Ju1gTlKMJbeT6tTO0vh7WNfiBPPjoIXLN+OUqVtiKFs6SGw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -8274,9 +8275,9 @@
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
-      "version": "18.18.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
-      "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
+      "version": "18.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.0.tgz",
+      "integrity": "sha512-667KNhaD7U29mT5wf+TZUnrzPrlL2GNQ5N0BMjO2oNULhBxX0/FKCkm6JMu0Jh7Z+1LwUlR21ekd7KhIboNFNw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -8972,6 +8973,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
       "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
       "dev": true,
       "dependencies": {
         "webidl-conversions": "^7.0.0"
@@ -9060,9 +9062,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.587",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.587.tgz",
-      "integrity": "sha512-RyJX0q/zOkAoefZhB9XHghGeATVP0Q3mwA253XD/zj2OeXc+JZB9pCaEv6R578JUYaWM9PRhye0kXvd/V1cQ3Q==",
+      "version": "1.4.600",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.600.tgz",
+      "integrity": "sha512-KD6CWjf1BnQG+NsXuyiTDDT1eV13sKuYsOUioXkQweYTQIbgHkXPry9K7M+7cKtYHnSUPitVaLrXYB1jTkkYrw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -9382,15 +9384,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
-      "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.54.0.tgz",
+      "integrity": "sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.3",
-        "@eslint/js": "8.53.0",
+        "@eslint/js": "8.54.0",
         "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -14771,9 +14773,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -14975,12 +14977,12 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
@@ -15833,20 +15835,26 @@
       }
     },
     "node_modules/postcss-load-config": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
-      "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "dependencies": {
-        "lilconfig": "^2.0.5",
-        "yaml": "^2.1.1"
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
       },
       "engines": {
         "node": ">= 14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
       },
       "peerDependencies": {
         "postcss": ">=8.0.9",
@@ -15859,6 +15867,15 @@
         "ts-node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/lilconfig": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
+      "integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/postcss-load-config/node_modules/yaml": {
@@ -18112,9 +18129,9 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.20.0.tgz",
-      "integrity": "sha512-ozK8tl2hvLts8ijTs18iFruE+RoqmC/mqZhjs/+V7gS5W68JpJ3+FCTmLVqmR59MaUQ52MfGQuWsIqfsTbbJ0Q==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.21.0.tgz",
+      "integrity": "sha512-oTzw9248AF5bDTMk9MrxsRzEzivMlY+DWH0yWS4VYpMhNLhDWnN06pCtaUyPnqv/FpsdeNmRqmZugMABHRPdDA==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
@@ -19965,9 +19982,9 @@
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
-      "integrity": "sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -20935,11 +20952,11 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "requires": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "dependencies": {
@@ -20990,27 +21007,27 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
-      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
-      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
+      "integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.5",
         "@babel/helper-compilation-targets": "^7.22.15",
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.3",
+        "@babel/helpers": "^7.23.5",
+        "@babel/parser": "^7.23.5",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.3",
-        "@babel/types": "^7.23.3",
+        "@babel/traverse": "^7.23.5",
+        "@babel/types": "^7.23.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -21046,12 +21063,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
-      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
+      "integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.23.3",
+        "@babel/types": "^7.23.5",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -21097,17 +21114,17 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.15.tgz",
-      "integrity": "sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.5.tgz",
+      "integrity": "sha512-QELlRWxSpgdwdJzSJn4WAhKC+hvw/AtHbbrIoncKHkhKKR/luAlKkgBDcri1EzWAo8f8VvYVryEHN4tax/V67A==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
-        "@babel/helper-member-expression-to-functions": "^7.22.15",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-member-expression-to-functions": "^7.23.0",
         "@babel/helper-optimise-call-expression": "^7.22.5",
-        "@babel/helper-replace-supers": "^7.22.9",
+        "@babel/helper-replace-supers": "^7.22.20",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
         "semver": "^6.3.1"
@@ -21273,9 +21290,9 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ=="
     },
     "@babel/helper-validator-identifier": {
       "version": "7.22.20",
@@ -21283,9 +21300,9 @@
       "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
     },
     "@babel/helper-validator-option": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "dev": true
     },
     "@babel/helper-wrap-function": {
@@ -21300,20 +21317,20 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
-      "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.5.tgz",
+      "integrity": "sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0"
+        "@babel/traverse": "^7.23.5",
+        "@babel/types": "^7.23.5"
       }
     },
     "@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
@@ -21367,9 +21384,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
-      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
+      "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
       "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -21608,9 +21625,9 @@
       }
     },
     "@babel/plugin-transform-async-generator-functions": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.3.tgz",
-      "integrity": "sha512-59GsVNavGxAXCDDbakWSMJhajASb4kBCqDjqJsv+p5nKdbz7istmZ3HrX3L2LuiI80+zsOADCvooqQH3qGCucQ==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.4.tgz",
+      "integrity": "sha512-efdkfPhHYTtn0G6n2ddrESE91fgXxjlqLsnUtPWnJs4a4mZIbUaK7ffqKIIUKXSHwcDvaCVX6GXkaJJFqtX7jw==",
       "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -21640,9 +21657,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.3.tgz",
-      "integrity": "sha512-QPZxHrThbQia7UdvfpaRRlq/J9ciz1J4go0k+lPBXbgaNeY7IQrBj/9ceWjvMMI07/ZBzHl/F0R/2K0qH7jCVw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.4.tgz",
+      "integrity": "sha512-0QqbP6B6HOh7/8iNR4CQU2Th/bbRtBp4KS9vcaZd1fZ0wSh5Fyssg0UCIHwxh+ka+pNDREbVLQnHCMHKZfPwfw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -21659,9 +21676,9 @@
       }
     },
     "@babel/plugin-transform-class-static-block": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.3.tgz",
-      "integrity": "sha512-PENDVxdr7ZxKPyi5Ffc0LjXdnJyrJxyqF5T5YjlVg4a0VFfQHW0r8iAtRiDXkfHlu1wwcvdtnndGYIeJLSuRMQ==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.4.tgz",
+      "integrity": "sha512-nsWu/1M+ggti1SOALj3hfx5FXzAY06fwPJsUZD4/A5e1bWi46VUIWtD+kOX6/IdhXGsXBWllLFDSnqSCdUNydQ==",
       "dev": true,
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.22.15",
@@ -21670,9 +21687,9 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.3.tgz",
-      "integrity": "sha512-FGEQmugvAEu2QtgtU0uTASXevfLMFfBeVCIIdcQhn/uBQsMTjBajdnAtanQlOcuihWh10PZ7+HWvc7NtBwP74w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.5.tgz",
+      "integrity": "sha512-jvOTR4nicqYC9yzOHIhXG5emiFEOpappSJAl73SDSEDcybD+Puuze8Tnpb9p9qEyYup24tq891gkaygIFvWDqg==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -21725,9 +21742,9 @@
       }
     },
     "@babel/plugin-transform-dynamic-import": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.23.3.tgz",
-      "integrity": "sha512-vTG+cTGxPFou12Rj7ll+eD5yWeNl5/8xvQvF08y5Gv3v4mZQoyFf8/n9zg4q5vvCWt5jmgymfzMAldO7orBn7A==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.23.4.tgz",
+      "integrity": "sha512-V6jIbLhdJK86MaLh4Jpghi8ho5fGzt3imHOBu/x0jlBaPYqDoWz4RDXjmMOfnh+JWNaQleEAByZLV0QzBT4YQQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -21745,9 +21762,9 @@
       }
     },
     "@babel/plugin-transform-export-namespace-from": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.23.3.tgz",
-      "integrity": "sha512-yCLhW34wpJWRdTxxWtFZASJisihrfyMOTOQexhVzA78jlU+dH7Dw+zQgcPepQ5F3C6bAIiblZZ+qBggJdHiBAg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.23.4.tgz",
+      "integrity": "sha512-GzuSBcKkx62dGzZI1WVgTWvkkz84FZO5TC5T8dl/Tht/rAla6Dg/Mz9Yhypg+ezVACf/rgDuQt3kbWEv7LdUDQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -21775,9 +21792,9 @@
       }
     },
     "@babel/plugin-transform-json-strings": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.23.3.tgz",
-      "integrity": "sha512-H9Ej2OiISIZowZHaBwF0tsJOih1PftXJtE8EWqlEIwpc7LMTGq0rPOrywKLQ4nefzx8/HMR0D3JGXoMHYvhi0A==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.23.4.tgz",
+      "integrity": "sha512-81nTOqM1dMwZ/aRXQ59zVubN9wHGqk6UtqRK+/q+ciXmRy8fSolhGVvG09HHRGo4l6fr/c4ZhXUQH0uFW7PZbg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -21794,9 +21811,9 @@
       }
     },
     "@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.23.3.tgz",
-      "integrity": "sha512-+pD5ZbxofyOygEp+zZAfujY2ShNCXRpDRIPOiBmTO693hhyOEteZgl876Xs9SAHPQpcV0vz8LvA/T+w8AzyX8A==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.23.4.tgz",
+      "integrity": "sha512-Mc/ALf1rmZTP4JKKEhUwiORU+vcfarFVLfcFiolKUo6sewoxSEgl36ak5t+4WamRsNr6nzjZXQjM35WsU+9vbg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -21875,9 +21892,9 @@
       }
     },
     "@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.23.3.tgz",
-      "integrity": "sha512-xzg24Lnld4DYIdysyf07zJ1P+iIfJpxtVFOzX4g+bsJ3Ng5Le7rXx9KwqKzuyaUeRnt+I1EICwQITqc0E2PmpA==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.23.4.tgz",
+      "integrity": "sha512-jHE9EVVqHKAQx+VePv5LLGHjmHSJR76vawFPTdlxR/LVJPfOEGxREQwQfjuZEOPTwG92X3LINSh3M40Rv4zpVA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -21885,9 +21902,9 @@
       }
     },
     "@babel/plugin-transform-numeric-separator": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.23.3.tgz",
-      "integrity": "sha512-s9GO7fIBi/BLsZ0v3Rftr6Oe4t0ctJ8h4CCXfPoEJwmvAPMyNrfkOOJzm6b9PX9YXcCJWWQd/sBF/N26eBiMVw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.23.4.tgz",
+      "integrity": "sha512-mps6auzgwjRrwKEZA05cOwuDc9FAzoyFS4ZsG/8F43bTLf/TgkJg7QXOrPO1JO599iA3qgK9MXdMGOEC8O1h6Q==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -21895,9 +21912,9 @@
       }
     },
     "@babel/plugin-transform-object-rest-spread": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.3.tgz",
-      "integrity": "sha512-VxHt0ANkDmu8TANdE9Kc0rndo/ccsmfe2Cx2y5sI4hu3AukHQ5wAu4cM7j3ba8B9548ijVyclBU+nuDQftZsog==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.4.tgz",
+      "integrity": "sha512-9x9K1YyeQVw0iOXJlIzwm8ltobIIv7j2iLyP2jIhEbqPRQ7ScNgwQufU2I0Gq11VjyG4gI4yMXt2VFags+1N3g==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.23.3",
@@ -21918,9 +21935,9 @@
       }
     },
     "@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.23.3.tgz",
-      "integrity": "sha512-LxYSb0iLjUamfm7f1D7GpiS4j0UAC8AOiehnsGAP8BEsIX8EOi3qV6bbctw8M7ZvLtcoZfZX5Z7rN9PlWk0m5A==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.23.4.tgz",
+      "integrity": "sha512-XIq8t0rJPHf6Wvmbn9nFxU6ao4c7WhghTR5WyV8SrJfUFzyxhCm4nhC+iAp3HFhbAKLfYpgzhJ6t4XCtVwqO5A==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -21928,9 +21945,9 @@
       }
     },
     "@babel/plugin-transform-optional-chaining": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.3.tgz",
-      "integrity": "sha512-zvL8vIfIUgMccIAK1lxjvNv572JHFJIKb4MWBz5OGdBQA0fB0Xluix5rmOby48exiJc987neOmP/m9Fnpkz3Tg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.4.tgz",
+      "integrity": "sha512-ZU8y5zWOfjM5vZ+asjgAPwDaBjJzgufjES89Rs4Lpq63O300R/kOz30WCLo6BxxX6QVEilwSlpClnG5cZaikTA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -21958,9 +21975,9 @@
       }
     },
     "@babel/plugin-transform-private-property-in-object": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.23.3.tgz",
-      "integrity": "sha512-a5m2oLNFyje2e/rGKjVfAELTVI5mbA0FeZpBnkOWWV7eSmKQ+T/XW0Vf+29ScLzSxX+rnsarvU0oie/4m6hkxA==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.23.4.tgz",
+      "integrity": "sha512-9G3K1YqTq3F4Vt88Djx1UZ79PDyj+yKRnUy7cZGSMe+a7jkwD259uKKuUzQlPkGam7R+8RJwh5z4xO27fA1o2A==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -21997,16 +22014,16 @@
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.15.tgz",
-      "integrity": "sha512-oKckg2eZFa8771O/5vi7XeTvmM6+O9cxZu+kanTU7tD4sin5nO/G8jGJhq8Hvt2Z0kUoEDRayuZLaUlYl8QuGA==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.23.4.tgz",
+      "integrity": "sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/plugin-syntax-jsx": "^7.22.5",
-        "@babel/types": "^7.22.15"
+        "@babel/plugin-syntax-jsx": "^7.23.3",
+        "@babel/types": "^7.23.4"
       }
     },
     "@babel/plugin-transform-react-jsx-development": {
@@ -22048,9 +22065,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.3.tgz",
-      "integrity": "sha512-XcQ3X58CKBdBnnZpPaQjgVMePsXtSZzHoku70q9tUAQp02ggPQNM04BF3RvlW1GSM/McbSOQAzEK4MXbS7/JFg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.4.tgz",
+      "integrity": "sha512-ITwqpb6V4btwUG0YJR82o2QvmWrLgDnx/p2A3CTPYGaRgULkDiC0DRA2C4jlRB9uXGUEfaSS/IGHfVW+ohzYDw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.22.15",
@@ -22116,13 +22133,13 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.3.tgz",
-      "integrity": "sha512-ogV0yWnq38CFwH20l2Afz0dfKuZBx9o/Y2Rmh5vuSS0YD1hswgEgTfyTzuSrT2q9btmHRSqYoSfwFUVaC1M1Jw==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.5.tgz",
+      "integrity": "sha512-2fMkXEJkrmwgu2Bsv1Saxgj30IXZdJ+84lQcKKI7sm719oXs0BBw2ZENKdJdR1PjWndgLCEBNXJOri0fk7RYQA==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-create-class-features-plugin": "^7.23.5",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/plugin-syntax-typescript": "^7.23.3"
       }
@@ -22167,15 +22184,15 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.3.tgz",
-      "integrity": "sha512-ovzGc2uuyNfNAs/jyjIGxS8arOHS5FENZaNn4rtE7UdKMMkqHCvboHfcuhWLZNX5cB44QfcGNWjaevxMzzMf+Q==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.5.tgz",
+      "integrity": "sha512-0d/uxVD6tFGWXGDSfyMD1p2otoaKmu6+GD+NfAx0tMaH+dxORnp7T9TaVQ6mKyya7iBtCIVxHjWT7MuzzM9z+A==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.23.3",
+        "@babel/compat-data": "^7.23.5",
         "@babel/helper-compilation-targets": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/helper-validator-option": "^7.22.15",
+        "@babel/helper-validator-option": "^7.23.5",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
         "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.3",
@@ -22199,25 +22216,25 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.23.3",
-        "@babel/plugin-transform-async-generator-functions": "^7.23.3",
+        "@babel/plugin-transform-async-generator-functions": "^7.23.4",
         "@babel/plugin-transform-async-to-generator": "^7.23.3",
         "@babel/plugin-transform-block-scoped-functions": "^7.23.3",
-        "@babel/plugin-transform-block-scoping": "^7.23.3",
+        "@babel/plugin-transform-block-scoping": "^7.23.4",
         "@babel/plugin-transform-class-properties": "^7.23.3",
-        "@babel/plugin-transform-class-static-block": "^7.23.3",
-        "@babel/plugin-transform-classes": "^7.23.3",
+        "@babel/plugin-transform-class-static-block": "^7.23.4",
+        "@babel/plugin-transform-classes": "^7.23.5",
         "@babel/plugin-transform-computed-properties": "^7.23.3",
         "@babel/plugin-transform-destructuring": "^7.23.3",
         "@babel/plugin-transform-dotall-regex": "^7.23.3",
         "@babel/plugin-transform-duplicate-keys": "^7.23.3",
-        "@babel/plugin-transform-dynamic-import": "^7.23.3",
+        "@babel/plugin-transform-dynamic-import": "^7.23.4",
         "@babel/plugin-transform-exponentiation-operator": "^7.23.3",
-        "@babel/plugin-transform-export-namespace-from": "^7.23.3",
+        "@babel/plugin-transform-export-namespace-from": "^7.23.4",
         "@babel/plugin-transform-for-of": "^7.23.3",
         "@babel/plugin-transform-function-name": "^7.23.3",
-        "@babel/plugin-transform-json-strings": "^7.23.3",
+        "@babel/plugin-transform-json-strings": "^7.23.4",
         "@babel/plugin-transform-literals": "^7.23.3",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.23.3",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.23.4",
         "@babel/plugin-transform-member-expression-literals": "^7.23.3",
         "@babel/plugin-transform-modules-amd": "^7.23.3",
         "@babel/plugin-transform-modules-commonjs": "^7.23.3",
@@ -22225,15 +22242,15 @@
         "@babel/plugin-transform-modules-umd": "^7.23.3",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
         "@babel/plugin-transform-new-target": "^7.23.3",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.23.3",
-        "@babel/plugin-transform-numeric-separator": "^7.23.3",
-        "@babel/plugin-transform-object-rest-spread": "^7.23.3",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.23.4",
+        "@babel/plugin-transform-numeric-separator": "^7.23.4",
+        "@babel/plugin-transform-object-rest-spread": "^7.23.4",
         "@babel/plugin-transform-object-super": "^7.23.3",
-        "@babel/plugin-transform-optional-catch-binding": "^7.23.3",
-        "@babel/plugin-transform-optional-chaining": "^7.23.3",
+        "@babel/plugin-transform-optional-catch-binding": "^7.23.4",
+        "@babel/plugin-transform-optional-chaining": "^7.23.4",
         "@babel/plugin-transform-parameters": "^7.23.3",
         "@babel/plugin-transform-private-methods": "^7.23.3",
-        "@babel/plugin-transform-private-property-in-object": "^7.23.3",
+        "@babel/plugin-transform-private-property-in-object": "^7.23.4",
         "@babel/plugin-transform-property-literals": "^7.23.3",
         "@babel/plugin-transform-regenerator": "^7.23.3",
         "@babel/plugin-transform-reserved-words": "^7.23.3",
@@ -22307,9 +22324,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
+      "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
@@ -22326,29 +22343,29 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
-      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
+      "integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.5",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.3",
-        "@babel/types": "^7.23.3",
+        "@babel/parser": "^7.23.5",
+        "@babel/types": "^7.23.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
-      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
+      "integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
       "requires": {
-        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
@@ -22651,9 +22668,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
-      "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.54.0.tgz",
+      "integrity": "sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==",
       "dev": true
     },
     "@faizaanceg/pandora": {
@@ -23116,19 +23133,19 @@
       },
       "dependencies": {
         "@wordpress/api-fetch": {
-          "version": "6.43.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.43.0.tgz",
-          "integrity": "sha512-DYtawNaOHDxgIl+B/E1oU+VMhFJJfy/oYR5e7+PFUX0t0yHhHuH8XaWKpZvpvo0Y/GOuJ2NkDcJDqSZXD2TFYw==",
+          "version": "6.44.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.44.0.tgz",
+          "integrity": "sha512-d8ouvBiKDFu67O9Y8MtlUR2YojCAjmLf0LuBKsSOS5r3MOiwte1tQwsLdzFmGYkdCK09mZhT3UVKdOOiAC3kKA==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/i18n": "^4.46.0",
-            "@wordpress/url": "^3.47.0"
+            "@wordpress/i18n": "^4.47.0",
+            "@wordpress/url": "^3.48.0"
           }
         },
         "@wordpress/url": {
-          "version": "3.47.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.47.0.tgz",
-          "integrity": "sha512-eDj7eDDYS8/UaUioulM54JkhmYvplvwW8+rbidR0fKZLr9zu3mfM7vrlwpIv9OK2RMenqEvu7Ij2gc5n/YEAcQ==",
+          "version": "3.48.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.48.0.tgz",
+          "integrity": "sha512-12bjIBBGcA5X8RPvUURLJZzpB60O5DI3WxQVIBBKPF4Mv8nUmgT4uemGzf5/ble8lqzJVntyEhEWKPOxEbUbJg==",
           "requires": {
             "@babel/runtime": "^7.16.0",
             "remove-accents": "^0.5.0"
@@ -23150,9 +23167,9 @@
       }
     },
     "@newfold/ui-component-library": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@newfold/ui-component-library/-/ui-component-library-1.0.0.tgz",
-      "integrity": "sha512-zEP2oe+WHu1VJ4B34tKb+8cOdSIefSZ5sappZHLJtA3DM+LhP4NHoVvLt34YYNdm9Zq1mL/M5PH9uqCbMQZFOg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@newfold/ui-component-library/-/ui-component-library-1.0.1.tgz",
+      "integrity": "sha512-p/nCSWcVNs7hOzUJNQXbyiQe82WAzUXbSENIvMX326FeLyETo0AtncqNUZJxABDIVQVQONu+19uRCAqCRvZBPQ==",
       "requires": {
         "@headlessui/react": "^1.7.8",
         "@heroicons/react": "^1.0.6",
@@ -23247,13 +23264,13 @@
       }
     },
     "@replayio/cypress": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@replayio/cypress/-/cypress-1.7.2.tgz",
-      "integrity": "sha512-Ld1fiLAyblvaeZMojf5wvh5i9s/aDWG8lp5Q8uaCYgj3SipmQ1E1CQ2S2iMKDbJjLMhWp+OKLWyWT9vmH8EvDQ==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@replayio/cypress/-/cypress-1.7.6.tgz",
+      "integrity": "sha512-jWHh5Q2UcaGQ/ghe7RMJlR/vfpAW9995dohxIRTB/laywiB2Bfk/Y/D/ZR+0MYV1Kx8XsXkOQRYDCx1F2cp0Cw==",
       "dev": true,
       "requires": {
-        "@replayio/replay": "^0.19.1",
-        "@replayio/test-utils": "^1.3.2",
+        "@replayio/replay": "^0.19.4",
+        "@replayio/test-utils": "^1.3.6",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "semver": "^7.5.2",
@@ -23264,9 +23281,9 @@
       }
     },
     "@replayio/replay": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@replayio/replay/-/replay-0.19.1.tgz",
-      "integrity": "sha512-7baMKu2sCAHdqiM6pvRf8RPWzTJzN6iTsqetB+zW/0Uo0BFqmXyTRRH4Q7FBxtRxLz/J5m9yOJIXMYnOveJqEQ==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@replayio/replay/-/replay-0.19.4.tgz",
+      "integrity": "sha512-T8XlT4jKVoQgPGNieYz3C++IowUVXWjqTMWNMcPrv0368h7MTTKrvnKCTTNmeDFXW819AeCRcCi+Xvgra2OzmQ==",
       "dev": true,
       "requires": {
         "@replayio/sourcemap-upload": "^1.1.1",
@@ -23303,12 +23320,12 @@
       }
     },
     "@replayio/test-utils": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@replayio/test-utils/-/test-utils-1.3.2.tgz",
-      "integrity": "sha512-xt9KGLSm57JWYeOoollr8tTZ4GomheZaJz4T12fDFqMNjtI9MOzJDE0/aY63ORsMV83QLiToZ0/mT8xWY6VKyA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@replayio/test-utils/-/test-utils-1.3.6.tgz",
+      "integrity": "sha512-GBcMwLyqqPkODtgyyy5/j3BPqcUqquHgAszbUlbCwWvgBc1TfUgNg9yrBCa5cR5tcdLE9m/h1taxEAqs2MKO8Q==",
       "dev": true,
       "requires": {
-        "@replayio/replay": "^0.19.1",
+        "@replayio/replay": "^0.19.4",
         "debug": "^4.3.4",
         "node-fetch": "^2.6.7",
         "uuid": "^8.3.2"
@@ -23581,9 +23598,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.4.tgz",
-      "integrity": "sha512-mLnSC22IC4vcWiuObSRjrLd9XcBTGf59vUSoq2jkQDJ/QQ8PMI9rSuzE+aEV8karUMbskw07bKYoUJCKTUaygg==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.20.7",
@@ -23662,9 +23679,9 @@
       }
     },
     "@types/connect-history-api-fallback": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.3.tgz",
-      "integrity": "sha512-6mfQ6iNvhSKCZJoY6sIG3m0pKkdUcweVNOLuBBKvoWGzl2yRxOJcYOTRyLKt3nxXvBLJWa6QkW//tgbIwJehmA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
+      "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
       "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
@@ -23672,9 +23689,9 @@
       }
     },
     "@types/eslint": {
-      "version": "8.44.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.7.tgz",
-      "integrity": "sha512-f5ORu2hcBbKei97U73mf+l9t4zTGl74IqZ0GQk4oVea/VS8tQZYkUveSYojk+frraAVYId0V2WC9O4PTNru2FQ==",
+      "version": "8.44.8",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.8.tgz",
+      "integrity": "sha512-4K8GavROwhrYl2QXDXm0Rv9epkA8GBFu0EI+XrrnnuCl7u8CWBRusX7fXJfanhZTDWSAL24gDI/UqXyUM0Injw==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -23836,23 +23853,23 @@
       "dev": true
     },
     "@types/mousetrap": {
-      "version": "1.6.14",
-      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.14.tgz",
-      "integrity": "sha512-aY69yje/bZllr99dbIcQwB365YDH/9myLodpxQ8cQZhGfavICi389aRvwa5LUoW+gTpcZKHjVI/sc0dDjUqVuw=="
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
+      "integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw=="
     },
     "@types/node": {
-      "version": "20.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.1.tgz",
-      "integrity": "sha512-HhmzZh5LSJNS5O8jQKpJ/3ZcrrlG6L70hpGqMIAoM9YVD0YBRNWYsfwcXq8VnSjlNpCpgLzMXdiPo+dxcvSmiA==",
+      "version": "20.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.1.tgz",
+      "integrity": "sha512-T2qwhjWwGH81vUEx4EXmBKsTJRXFXNZTL4v0gi01+zyBmCwzE6TyHszqX01m+QHTEq+EZNo13NeJIdEqf+Myrg==",
       "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
     },
     "@types/node-forge": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.9.tgz",
-      "integrity": "sha512-meK88cx/sTalPSLSoCzkiUB4VPIFHmxtXm5FaaqRDqBX2i/Sy8bJ4odsan0b20RBjPh06dAQ+OTTdnyQyhJZyQ==",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.10.tgz",
+      "integrity": "sha512-y6PJDYN4xYBxwd22l+OVH35N+1fCYWiuC3aiP2SlXVE6Lo7SS+rSx9r89hLxrP4pn6n1lBGhHJ12pj3F3Mpttw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -23870,9 +23887,9 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
     },
     "@types/prop-types": {
-      "version": "15.7.10",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.10.tgz",
-      "integrity": "sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A=="
+      "version": "15.7.11",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "@types/qs": {
       "version": "6.9.10",
@@ -23887,9 +23904,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.14.51",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.51.tgz",
-      "integrity": "sha512-4T/wsDXStA5OUGTj6w2INze3ZCz22IwQiWcApgqqNRU2A6vNUIPXpNkjAMUFxx6diYPVkvz+d7gEtU7AZ+0Xqg==",
+      "version": "16.14.52",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.52.tgz",
+      "integrity": "sha512-4+ZN73hgRW3Gang3QMqWjrqPPkf+lWZYiyG4uXtUbpd+7eiBDw6Gemila6rXDd8DorADupTiIERL6Mb5BQTF2w==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -23904,9 +23921,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "16.9.22",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.22.tgz",
-      "integrity": "sha512-x7T/NHsYiKfbIwZDzBTThTF3a3UPNLanOY4wbEe4Hy44hf0tWIZTu8VZJTkB/FKcr4cbfDq0E7y3jSLJh4cpow==",
+      "version": "16.9.24",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.24.tgz",
+      "integrity": "sha512-Gcmq2JTDheyWn/1eteqyzzWKSqDjYU6KYsIvH7thb7CR5OYInAWOX+7WnKf6PaU/cbdOc4szJItcDEJO7UGmfA==",
       "requires": {
         "@types/react": "^16"
       }
@@ -23927,14 +23944,14 @@
       "dev": true
     },
     "@types/scheduler": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.6.tgz",
-      "integrity": "sha512-Vlktnchmkylvc9SnwwwozTv04L/e1NykF5vgoQ0XTmI8DD+wxfjQuHuvHS3p0r2jz2x2ghPs2h1FVeDirIteWA=="
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "@types/semver": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
-      "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
     },
     "@types/send": {
@@ -23974,9 +23991,9 @@
       "dev": true
     },
     "@types/sizzle": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.6.tgz",
-      "integrity": "sha512-m04Om5Gz6kbjUwAQ7XJJQ30OdEFsSmAVsvn4NYwcTRyMVpKKa1aPuESw1n2CxS5fYkOQv3nHgDKeNa8e76fUkw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
+      "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
       "dev": true
     },
     "@types/sockjs": {
@@ -23989,9 +24006,9 @@
       }
     },
     "@types/source-list-map": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.5.tgz",
-      "integrity": "sha512-cHBTLeIGIREJx839cDfMLKWao+FaJOlaPz4mnFHXUzShS8sXhzw6irhvIpYvp28TbTmTeAt3v+QgHMANsGbQtA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.6.tgz",
+      "integrity": "sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -24001,9 +24018,9 @@
       "dev": true
     },
     "@types/tapable": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.11.tgz",
-      "integrity": "sha512-R3ltemSqZ/TKOBeyy+GBfZCLX3AYpxqarIbUMNe7+lxdazJp4iWLFpmjgBeZoRiKrWNImer1oWOlG2sDR6vGaw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.12.tgz",
+      "integrity": "sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==",
       "dev": true
     },
     "@types/tough-cookie": {
@@ -24030,9 +24047,9 @@
       }
     },
     "@types/webpack": {
-      "version": "4.41.36",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.36.tgz",
-      "integrity": "sha512-pF+DVW1pMLmgsPXqJr5QimdxIzOhe8oGKB98gdqAm0egKBy1lOLD5mRxbYboMQRkpYcG7BYcpqYblpKyvE7vhQ==",
+      "version": "4.41.38",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.38.tgz",
+      "integrity": "sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -24063,18 +24080,18 @@
       }
     },
     "@types/ws": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
-      "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/yargs": {
-      "version": "17.0.31",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.31.tgz",
-      "integrity": "sha512-bocYSx4DI8TmdlvxqGpVNXOgCNR1Jj0gNPhhAY+iz1rgKDAaYrAYdFYnhDV1IFuiuVc9HkOwyDcFxaTElF3/wg==",
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -24447,15 +24464,15 @@
       }
     },
     "@wordpress/babel-plugin-import-jsx-pragma": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.29.0.tgz",
-      "integrity": "sha512-VPAn1iVZae1sQ6QaiMKbp3AzFPbhBl6YQeDr3AKpj24GTiUmsho6WgxijzyhBEBX5xPHVCahhQ8mjiZ5Ql6FwA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.30.0.tgz",
+      "integrity": "sha512-UKkyFmEYk1UTO0ZPun6Kw5dNflTEDpDK/6RxAqxbVrsIWUVSkVahwBnqfS0v5LuvVU8y+5vJSR/WjlnKEmS3Sg==",
       "dev": true
     },
     "@wordpress/babel-preset-default": {
-      "version": "7.30.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.30.0.tgz",
-      "integrity": "sha512-O/IA8Jvh6MzlTyeo0As2chhZ2w6WdvMYSjjTDDC66SkbnUxUf4jWqehncHGrtQLoQJfwsCUnyWSH4ePb/j+kIw==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.31.0.tgz",
+      "integrity": "sha512-LAiTOlolFvKW6xmL6qRkdbPG09LPwAsmDepz4zWrFXJZHSImDeO2QXHecF1GnFyzLLKr1myHR5MbN3K5MSzpqQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.16.0",
@@ -24464,9 +24481,9 @@
         "@babel/preset-env": "^7.16.0",
         "@babel/preset-typescript": "^7.16.0",
         "@babel/runtime": "^7.16.0",
-        "@wordpress/babel-plugin-import-jsx-pragma": "^4.29.0",
-        "@wordpress/browserslist-config": "^5.29.0",
-        "@wordpress/warning": "^2.46.0",
+        "@wordpress/babel-plugin-import-jsx-pragma": "^4.30.0",
+        "@wordpress/browserslist-config": "^5.30.0",
+        "@wordpress/warning": "^2.47.0",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
         "react": "^18.2.0"
@@ -24484,15 +24501,15 @@
       }
     },
     "@wordpress/base-styles": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.37.0.tgz",
-      "integrity": "sha512-HxYlZHHpq0XDd+/ixTjB0g2smw8NIhal0gZgKJsQSPra/TN5Swjt0e3QwW3MBGZKWhV9poNmsBGNZonVCe9bSA==",
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.38.0.tgz",
+      "integrity": "sha512-w491MMHfoCHdWibyTAcmGWvXwNMptslFQOU+jQ5DVeDIgDux1KLo/7oZ41CCHwqYayrCf60BC9+JopDXqq1H+g==",
       "dev": true
     },
     "@wordpress/browserslist-config": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.29.0.tgz",
-      "integrity": "sha512-sVDgPWcI3wdKd3cIvgf/NLO7HtEkwyV4bWuSztzoemNMGQW17BhH2Blx46HnJFXm9ooYw4SpAOyioHTkuT+JFg==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.30.0.tgz",
+      "integrity": "sha512-HFgLCkvvxba+j7/qNjVn1od38tvMm1xVlIJBR+zukkTvvLu/AkdelWKAQpvAoFAXMaZJ7239VxDVBYbVolf6FQ==",
       "dev": true
     },
     "@wordpress/components": {
@@ -24583,18 +24600,18 @@
       }
     },
     "@wordpress/data": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.16.0.tgz",
-      "integrity": "sha512-FEfHR5wlbtqssSVzey45Yq9+sFaFxiKZrY6MInkOVY7B/GtdSDpKDioDdTgmHKOnyaal4l1KHAE0bVEoMLfaFQ==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.17.0.tgz",
+      "integrity": "sha512-0FfNL4mHMkX8cBbGAjP8EJ/RGOvf/74qyhBXiLEGUz6swhW6RFrSPm7Dkqe5cMRqXDGoJn15OsOFIuLRllwVoQ==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.23.0",
-        "@wordpress/deprecated": "^3.46.0",
-        "@wordpress/element": "^5.23.0",
-        "@wordpress/is-shallow-equal": "^4.46.0",
-        "@wordpress/priority-queue": "^2.46.0",
-        "@wordpress/private-apis": "^0.28.0",
-        "@wordpress/redux-routine": "^4.46.0",
+        "@wordpress/compose": "^6.24.0",
+        "@wordpress/deprecated": "^3.47.0",
+        "@wordpress/element": "^5.24.0",
+        "@wordpress/is-shallow-equal": "^4.47.0",
+        "@wordpress/priority-queue": "^2.47.0",
+        "@wordpress/private-apis": "^0.29.0",
+        "@wordpress/redux-routine": "^4.47.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -24605,9 +24622,9 @@
       },
       "dependencies": {
         "@types/react": {
-          "version": "18.2.37",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.37.tgz",
-          "integrity": "sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==",
+          "version": "18.2.39",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.39.tgz",
+          "integrity": "sha512-Oiw+ppED6IremMInLV4HXGbfbG6GyziY3kqAwJYOR0PNbkYDmLWQA3a95EhdSmamsvbkJN96ZNN+YD+fGjzSBA==",
           "requires": {
             "@types/prop-types": "*",
             "@types/scheduler": "*",
@@ -24615,27 +24632,27 @@
           }
         },
         "@types/react-dom": {
-          "version": "18.2.15",
-          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.15.tgz",
-          "integrity": "sha512-HWMdW+7r7MR5+PZqJF6YFNSCtjz1T0dsvo/f1BV6HkV+6erD/nA7wd9NM00KVG83zf2nJ7uATPO9ttdIPvi3gg==",
+          "version": "18.2.17",
+          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz",
+          "integrity": "sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==",
           "requires": {
             "@types/react": "*"
           }
         },
         "@wordpress/compose": {
-          "version": "6.23.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.23.0.tgz",
-          "integrity": "sha512-MMWwYkbmA4IkdZQ/p3BMvgD9MvCGK2lJd8PjnftDw6NjRteXyA6CQjP1h+/mTlNJvHytqRu2cNPey0V0mnRx6A==",
+          "version": "6.24.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.24.0.tgz",
+          "integrity": "sha512-aO0HWi12Y7Do5hyGEOXcRtRTIn7P/t4RrHYMTsHvufCrt6ZCLKvY2vBEaDA8XnWFQZ/Tzo4fBAnxAAxDt1DtEw==",
           "requires": {
             "@babel/runtime": "^7.16.0",
             "@types/mousetrap": "^1.6.8",
-            "@wordpress/deprecated": "^3.46.0",
-            "@wordpress/dom": "^3.46.0",
-            "@wordpress/element": "^5.23.0",
-            "@wordpress/is-shallow-equal": "^4.46.0",
-            "@wordpress/keycodes": "^3.46.0",
-            "@wordpress/priority-queue": "^2.46.0",
-            "@wordpress/undo-manager": "^0.6.0",
+            "@wordpress/deprecated": "^3.47.0",
+            "@wordpress/dom": "^3.47.0",
+            "@wordpress/element": "^5.24.0",
+            "@wordpress/is-shallow-equal": "^4.47.0",
+            "@wordpress/keycodes": "^3.47.0",
+            "@wordpress/priority-queue": "^2.47.0",
+            "@wordpress/undo-manager": "^0.7.0",
             "change-case": "^4.1.2",
             "clipboard": "^2.0.8",
             "mousetrap": "^1.6.5",
@@ -24643,32 +24660,32 @@
           }
         },
         "@wordpress/deprecated": {
-          "version": "3.46.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.46.0.tgz",
-          "integrity": "sha512-i7stkwWr9vUc2A9ILb0qIUfqtyjaG9yNbqRcfWDjqhOn6R4Drm4edwdpZKdYHSTiiH2qPCWZGTc6KVZm5wc9/Q==",
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.47.0.tgz",
+          "integrity": "sha512-Vq4h6LHGPUc/pqmLOANcPpiMrOVoTeZRDvKxE+ioR9ldEFo+uquMKrEmJZxXVXl0GZdMKQ4jGKx34z8S8VRwQw==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/hooks": "^3.46.0"
+            "@wordpress/hooks": "^3.47.0"
           }
         },
         "@wordpress/dom": {
-          "version": "3.46.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.46.0.tgz",
-          "integrity": "sha512-NiGBTpE7lzTAjkxw5HVp3EzyMxZA378/yed0id0krvEId4prmbIJWRwSNC+Yvn0nhuHczIl4wj9T9zYpksAcUg==",
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.47.0.tgz",
+          "integrity": "sha512-SY6wfAc4yrXYil8fm/uyeKQnPjGuc0G9Q1/5pUKO6dssst8fClsrxy+hXNl0FYFGWnAZBqg5ccrwYydrFt5k/g==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/deprecated": "^3.46.0"
+            "@wordpress/deprecated": "^3.47.0"
           }
         },
         "@wordpress/element": {
-          "version": "5.23.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.23.0.tgz",
-          "integrity": "sha512-6c1EG8UJDzJGX6yWJGIi78bgomWJ6rSkMRR9d0UBis9bm9YFBJDydsD9bNx6XItrMEXR7yykXblfGY2YUK3SAA==",
+          "version": "5.24.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.24.0.tgz",
+          "integrity": "sha512-El1E5jlZitrDouvde0dUF2yVRiPsxPnjxB9TU43EhahQ9eT8pwfUaH3I4NT8kUj2LD76WwU8fN7CEmBNBW+ofA==",
           "requires": {
             "@babel/runtime": "^7.16.0",
             "@types/react": "^18.0.21",
             "@types/react-dom": "^18.0.6",
-            "@wordpress/escape-html": "^2.46.0",
+            "@wordpress/escape-html": "^2.47.0",
             "change-case": "^4.1.2",
             "is-plain-object": "^5.0.0",
             "react": "^18.2.0",
@@ -24676,43 +24693,43 @@
           }
         },
         "@wordpress/escape-html": {
-          "version": "2.46.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.46.0.tgz",
-          "integrity": "sha512-sPjBUMTSqjDF1niqb6NnKim8Ju7zWVlgZoifO3cC+4DGZcRsKF78eTeuEojQJN7h/FHCjpKX3dvnr+ihv7syEQ==",
+          "version": "2.47.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.47.0.tgz",
+          "integrity": "sha512-bBGcTE5chneQJ3yETJyT2suyVtEJNfOiMVBV5qm606TyEzIDm18Sw2mPfOagiB1nOwDkAVfpSVD2NeGpit2alA==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
         },
         "@wordpress/hooks": {
-          "version": "3.46.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.46.0.tgz",
-          "integrity": "sha512-TTYNZwMZeATpkWmvAoShP43UONd/WPNTtsy1czMSyiqPzFhzGJbKD75CdJtPp5DqIAiuWQEuDmcxRAPcZ/1Qgw==",
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.47.0.tgz",
+          "integrity": "sha512-a0mZ+lSUBrmacJGXDnFTaz1O47sQgTCZi3LrY445WNc7cmiSlscTfeBxrUXaTF0ninzHJnE7evCIeKLbQC3dLQ==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
         },
         "@wordpress/is-shallow-equal": {
-          "version": "4.46.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.46.0.tgz",
-          "integrity": "sha512-1K5RTTi99ozF9vPKxoVl+RR6mSYy64DKYnijACDN9Sigzbe6OWeL6ky47r09G0JtDnRpzA0itIfFcV8iRNzpvA==",
+          "version": "4.47.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.47.0.tgz",
+          "integrity": "sha512-mfrw/GXtCzm5jciuXumabfJhJLzGU0EpGgXU9tDHw6CwDrtUMcM05qrvrXFk4IlE2hYFwuTkWryValMt3FFdoQ==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
         },
         "@wordpress/keycodes": {
-          "version": "3.46.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.46.0.tgz",
-          "integrity": "sha512-08ubCD321T85BZBUQuco2/vwIC5Pfzbw4CY7E2xR3rGzX3vb7SjDbKIqKeJL/UfYSmZF9GY+KaspSa1ywFtWiA==",
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.47.0.tgz",
+          "integrity": "sha512-dmYpqCWUoCM290YA5ApES9nqz/0D1JngIlZtel+BvELf8fj/jctdsT5wDB7dVdvZCuyr5SF+1Od00DYbMbb5oA==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/i18n": "^4.46.0",
+            "@wordpress/i18n": "^4.47.0",
             "change-case": "^4.1.2"
           }
         },
         "@wordpress/priority-queue": {
-          "version": "2.46.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.46.0.tgz",
-          "integrity": "sha512-ElNF4ONApHwwkEvP3Ta6Wly2RCljXLZpfyahOziq3rlK8gaeU82qRt13KBE85Djz+90yHSyDlX9YpmJebV9oPw==",
+          "version": "2.47.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.47.0.tgz",
+          "integrity": "sha512-ZA6BDYkEC3mY1UrEXYnihdb0GoJooxZ9ADPEDEnqY88EuUT8/eeIDOge7OzgatDa9ivzV8TP3Fs4C/mHg/s6dQ==",
           "requires": {
             "@babel/runtime": "^7.16.0",
             "requestidlecallback": "^0.3.0"
@@ -24756,29 +24773,29 @@
       }
     },
     "@wordpress/date": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.46.0.tgz",
-      "integrity": "sha512-IsbAXOVYJfSVISGppERnZMWVvvCo07bjSXSKhbd6CDgzTFDPCyUrOmv8tcMUdHw7a4jbL0w/KRMqdhN/C8A0JQ==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.47.0.tgz",
+      "integrity": "sha512-HIruX+wMaQWKYLCFIu6JeEEoqRYkhpL4cWfZ1lJG78wNsgq3vRiHzXQaXHcbmJQCq0PZOxtmeSzldPiUMFVNpg==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^3.46.0",
+        "@wordpress/deprecated": "^3.47.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
       "dependencies": {
         "@wordpress/deprecated": {
-          "version": "3.46.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.46.0.tgz",
-          "integrity": "sha512-i7stkwWr9vUc2A9ILb0qIUfqtyjaG9yNbqRcfWDjqhOn6R4Drm4edwdpZKdYHSTiiH2qPCWZGTc6KVZm5wc9/Q==",
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.47.0.tgz",
+          "integrity": "sha512-Vq4h6LHGPUc/pqmLOANcPpiMrOVoTeZRDvKxE+ioR9ldEFo+uquMKrEmJZxXVXl0GZdMKQ4jGKx34z8S8VRwQw==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/hooks": "^3.46.0"
+            "@wordpress/hooks": "^3.47.0"
           }
         },
         "@wordpress/hooks": {
-          "version": "3.46.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.46.0.tgz",
-          "integrity": "sha512-TTYNZwMZeATpkWmvAoShP43UONd/WPNTtsy1czMSyiqPzFhzGJbKD75CdJtPp5DqIAiuWQEuDmcxRAPcZ/1Qgw==",
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.47.0.tgz",
+          "integrity": "sha512-a0mZ+lSUBrmacJGXDnFTaz1O47sQgTCZi3LrY445WNc7cmiSlscTfeBxrUXaTF0ninzHJnE7evCIeKLbQC3dLQ==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
@@ -24786,9 +24803,9 @@
       }
     },
     "@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.29.0.tgz",
-      "integrity": "sha512-cYvTkjDvxpZSEjM1RRNciK/7W+RXC+qXXzbdRyGhkE0AzIspA7UAV3NoEyjtbL2V2wNJmBmsZKJf0wuYandDQA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.30.0.tgz",
+      "integrity": "sha512-Z3AcceaoHFvJdRNVp8rf6EI+rxK0gUMGMfcXYZPAoaDhP6Gt0bsbVMP5zQH2EYl7JHsbRZIQmMqd2fG5E/VjSQ==",
       "dev": true,
       "requires": {
         "json2php": "^0.0.7",
@@ -24814,9 +24831,9 @@
       }
     },
     "@wordpress/dom-ready": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.46.0.tgz",
-      "integrity": "sha512-Xq/TPuOZk1DjBzuo4fPj226Lo8uoKk0v1Tydnb263gRmAniSXdwEyrLPMbo8DOAqEUPI9ZRbqomJo/mBR2V8TA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.47.0.tgz",
+      "integrity": "sha512-VsqaTQJ5Z7Qa3Doi5qk4LMnW0K78JEKLYRcg3ohapgBrQ2tKTS67oWgJx2VgWz8ky6j9UosecSISP3zJHXfEeA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.0"
@@ -24837,9 +24854,9 @@
       }
     },
     "@wordpress/env": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.12.0.tgz",
-      "integrity": "sha512-AP4rvv9oEqNtAk1o+V/sDeSDuBnTrbAc1nGp2Q8KMgaxhNSnMB4gn5K6zggG5HF0GPWbR5YaFkID+2FvT0DPIw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.13.0.tgz",
+      "integrity": "sha512-rtrrBO22DnbLsdBlsGqlMQrjz1dZfbwGnxyKev+gFd1rSfmLs+1F8L89RHOx9vsGPixl5uRwoU/qgYo7Hf1NVQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -24914,12 +24931,12 @@
       }
     },
     "@wordpress/i18n": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.46.0.tgz",
-      "integrity": "sha512-5/61hd50KkqGgoQpf66DDft6sMTKfeGVdmZOt42GWymylxFSmbZLLnR8YafECQrmia/TdwIco5I4n0hIikYbNQ==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.47.0.tgz",
+      "integrity": "sha512-7qOeSChhI8drcnKAbpM2yP2HSWRR0U8xvww3Febd3kGhMKAUp8AMpjyC4rWucak4+Eg1HFfahurCmBt3FxgbYQ==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.46.0",
+        "@wordpress/hooks": "^3.47.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "sprintf-js": "^1.1.1",
@@ -24927,9 +24944,9 @@
       },
       "dependencies": {
         "@wordpress/hooks": {
-          "version": "3.46.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.46.0.tgz",
-          "integrity": "sha512-TTYNZwMZeATpkWmvAoShP43UONd/WPNTtsy1czMSyiqPzFhzGJbKD75CdJtPp5DqIAiuWQEuDmcxRAPcZ/1Qgw==",
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.47.0.tgz",
+          "integrity": "sha512-a0mZ+lSUBrmacJGXDnFTaz1O47sQgTCZi3LrY445WNc7cmiSlscTfeBxrUXaTF0ninzHJnE7evCIeKLbQC3dLQ==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
@@ -24950,9 +24967,9 @@
       }
     },
     "@wordpress/jest-console": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.17.0.tgz",
-      "integrity": "sha512-i1r0fGEZforoB1C8QuSfDDYwMycAJ/MqkEvhqWNLwcJy/JFYGWiKhkzhKfQ7aMUuwtrEJMb+41AOxelT565bDw==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.18.0.tgz",
+      "integrity": "sha512-OjPGbU1HgjLVNCLW9ROmdkw/qhpFL6Svlfv1aUVBrq5z1nJ7SrjRMeBSq4LJloOhTasSV9z7w4mhHJkMkfolJg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.0",
@@ -24960,12 +24977,12 @@
       }
     },
     "@wordpress/jest-preset-default": {
-      "version": "11.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.17.0.tgz",
-      "integrity": "sha512-Z1KAr9ViDLFiVAYsRkyAAwLBzxu6MTv1dAZpHhyZhYfxTNdTOnnHbNGHpsfv5OlT5xHxptkrESLP8klU2/kw4A==",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.18.0.tgz",
+      "integrity": "sha512-qwcDXfKkdBJnnsQAa0qkBsg94usGQCD914pWNeBg997qy/6zmVYVXpPjXoJXaC/lYbEIRAWGfry1RSiM6ZoC9g==",
       "dev": true,
       "requires": {
-        "@wordpress/jest-console": "^7.17.0",
+        "@wordpress/jest-console": "^7.18.0",
         "babel-jest": "^29.6.2"
       }
     },
@@ -24996,18 +25013,18 @@
       }
     },
     "@wordpress/npm-package-json-lint-config": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.31.0.tgz",
-      "integrity": "sha512-Y/MxST3sK/En6ZAChlyq5A7qtII9/1MLqk6o75yWPIDn1ew40V7iPBDkFKE3uMEPw1RW8rJ9WSQxNpcN+4k+Zg==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.32.0.tgz",
+      "integrity": "sha512-qyEnU9FoWpaa67pufu9fNmTCikiYhdKc4R01ffO+xX7wyJXMo0Z6EJog6ajU9E2+YL86AmAX+sO1CHuXcsxdbw==",
       "dev": true
     },
     "@wordpress/postcss-plugins-preset": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.30.0.tgz",
-      "integrity": "sha512-b/APWKhvocBrs+IHJNe7BOfFmvyRmOZEHEXvwPZy2iGIC95tA5p2/7h3/iSwUGNUcyGObqwd90Htfit9oIdQJA==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.31.0.tgz",
+      "integrity": "sha512-B6bHsCKxt25nkvWfIJH3l7kENKS20mpsiRIl5+CEES6kKfBwg4IPx+JyA/RPLFQcIQNtIYFft22p5bgT4VZcEg==",
       "dev": true,
       "requires": {
-        "@wordpress/base-styles": "^4.37.0",
+        "@wordpress/base-styles": "^4.38.0",
         "autoprefixer": "^10.2.5"
       }
     },
@@ -25026,17 +25043,17 @@
       }
     },
     "@wordpress/private-apis": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.28.0.tgz",
-      "integrity": "sha512-OAwLJfNIkSV2e77T7sXaGWtrbYuzhpusL0ufaR0hux6HfavHDmFuCjyyk3kUdq/GY6bFWDrWIvOTAkmVLYXdYg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.29.0.tgz",
+      "integrity": "sha512-8t4au9+IXXgJlxxOuYVYi8PKp0uWajNYILNfqCLB65jQEClzGNMQhU6MeJ9+kHN3gdOltMk7UzG28X+FTDlmkQ==",
       "requires": {
         "@babel/runtime": "^7.16.0"
       }
     },
     "@wordpress/redux-routine": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.46.0.tgz",
-      "integrity": "sha512-gvyCIp5zh9Nxj3+H6tD6+DrXal7ER68yuvWgWe6+XRWG0D/MhBog6xe1TCJ6Ec5tFcL30cEEy33YPxCiNnPtjA==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.47.0.tgz",
+      "integrity": "sha512-MK9evE2Tn3wVTJhSyAPgIVzMWRd5M9Bjfn4n1in1fbmrYN7qnFYdP4VUJwwYlKRDFpJUxC/4iyREBOryoxKDZw==",
       "requires": {
         "@babel/runtime": "^7.16.0",
         "is-plain-object": "^5.0.0",
@@ -25170,9 +25187,9 @@
       }
     },
     "@wordpress/stylelint-config": {
-      "version": "21.29.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.29.0.tgz",
-      "integrity": "sha512-8VetLM5CTg8iLgodgpY4x132Yf4gPWMMffqfAG8HFwwvVQxm0mjl/dNtj6RBrxemdTi7dHr1jnZvqU+XxQlHXQ==",
+      "version": "21.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.30.0.tgz",
+      "integrity": "sha512-PlvXzYgjn7OUaVTy2bahSr6oL/eu1OdRWxrZfGVNxF4jRswND/ThqOEHIzxETNGTe0ggZOyY+40St4Swlo1zZQ==",
       "dev": true,
       "requires": {
         "stylelint-config-recommended": "^6.0.0",
@@ -25180,18 +25197,18 @@
       }
     },
     "@wordpress/undo-manager": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.6.0.tgz",
-      "integrity": "sha512-u/oW1LAx0yANHzFHz/H1Tnopa7r/8q1D/bV2fescjQ947LLOpaImh7hlLn6ryEt8qCj2YSL9Ry2dDE2R/U1gQQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.7.0.tgz",
+      "integrity": "sha512-WhMKX/ETGUJr2GkaPgGwFF8gTU/PgikfvE2b2ZDjUglxIPYnujBa9S6w+kQPzwGniGJutHL1DFK+TmAaxoci9A==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^4.46.0"
+        "@wordpress/is-shallow-equal": "^4.47.0"
       },
       "dependencies": {
         "@wordpress/is-shallow-equal": {
-          "version": "4.46.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.46.0.tgz",
-          "integrity": "sha512-1K5RTTi99ozF9vPKxoVl+RR6mSYy64DKYnijACDN9Sigzbe6OWeL6ky47r09G0JtDnRpzA0itIfFcV8iRNzpvA==",
+          "version": "4.47.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.47.0.tgz",
+          "integrity": "sha512-mfrw/GXtCzm5jciuXumabfJhJLzGU0EpGgXU9tDHw6CwDrtUMcM05qrvrXFk4IlE2hYFwuTkWryValMt3FFdoQ==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
@@ -25208,9 +25225,9 @@
       }
     },
     "@wordpress/warning": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.46.0.tgz",
-      "integrity": "sha512-oyUNmDz64nF8vnS9LaobXMIx6K5w+XhAtvo3Cjv3kCVIuWFwpxoeMus3pUo1A7v2H9zcW+E87zwEuqsLPYjNfQ==",
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.47.0.tgz",
+      "integrity": "sha512-lmpLNI8Si7HrSY0LBBtp7Z6NzAkh1y7yeJI0LZw17EsJ0MM5FSXqXJRrNY7L4tM8G/vv3OacUw1mRAZX7bzBRQ==",
       "dev": true
     },
     "@xtuc/ieee754": {
@@ -26223,9 +26240,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001563",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001563.tgz",
-      "integrity": "sha512-na2WUmOxnwIZtwnFI2CZ/3er0wdNzU7hN+cPYz/z2ajHThnkWjNBOpEPP4n+4r2WPM847JaMotaJE3bnfzjyKw==",
+      "version": "1.0.30001565",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
+      "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
       "dev": true
     },
     "capital-case": {
@@ -26419,9 +26436,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
-      "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true
     },
     "cli-table3": {
@@ -26812,24 +26829,24 @@
       }
     },
     "core-js": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.2.tgz",
-      "integrity": "sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.3.tgz",
+      "integrity": "sha512-lo0kOocUlLKmm6kv/FswQL8zbkH7mVsLJ/FULClOhv8WRVmKLVcs6XPNQAzstfeJTCHMyButEwG+z1kHxHoDZw==",
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.2.tgz",
-      "integrity": "sha512-axfo+wxFVxnqf8RvxTzoAlzW4gRoacrHeoFlc9n0x50+7BEyZL/Rt3hicaED1/CEd7I6tPCPVUYcJwCMO5XUYw==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.3.tgz",
+      "integrity": "sha512-cNzGqFsh3Ot+529GIXacjTJ7kegdt5fPXxCBVS1G0iaZpuo/tBz399ymceLJveQhFFZ8qThHiP3fzuoQjKN2ow==",
       "dev": true,
       "requires": {
         "browserslist": "^4.22.1"
       }
     },
     "core-js-pure": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.33.2.tgz",
-      "integrity": "sha512-a8zeCdyVk7uF2elKIGz67AjcXOxjRbwOLz8SbklEso1V+2DoW4OkAMZN9S9GBgvZIaqQi/OemFX4OiSoQEmg1Q==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.33.3.tgz",
+      "integrity": "sha512-taJ00IDOP+XYQEA2dAe4ESkmHt1fL8wzYDo3mRWQey8uO9UojlBFMneA65kMyxfYP7106c6LzWaq7/haDT6BCQ==",
       "dev": true
     },
     "core-util-is": {
@@ -27110,9 +27127,9 @@
       }
     },
     "cypress": {
-      "version": "13.5.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.5.1.tgz",
-      "integrity": "sha512-yqLViT0D/lPI8Kkm7ciF/x/DCK/H/DnogdGyiTnQgX4OVR2aM30PtK+kvklTOD1u3TuItiD9wUQAF8EYWtyZug==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.0.tgz",
+      "integrity": "sha512-quIsnFmtj4dBUEJYU4OH0H12bABJpSujvWexC24Ju1gTlKMJbeT6tTO0vh7WNfiBPPjoIXLN+OUqVtiKFs6SGw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",
@@ -27161,9 +27178,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.18.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
-          "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
+          "version": "18.19.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.0.tgz",
+          "integrity": "sha512-667KNhaD7U29mT5wf+TZUnrzPrlL2GNQ5N0BMjO2oNULhBxX0/FKCkm6JMu0Jh7Z+1LwUlR21ekd7KhIboNFNw==",
           "dev": true,
           "requires": {
             "undici-types": "~5.26.4"
@@ -27763,9 +27780,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.587",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.587.tgz",
-      "integrity": "sha512-RyJX0q/zOkAoefZhB9XHghGeATVP0Q3mwA253XD/zj2OeXc+JZB9pCaEv6R578JUYaWM9PRhye0kXvd/V1cQ3Q==",
+      "version": "1.4.600",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.600.tgz",
+      "integrity": "sha512-KD6CWjf1BnQG+NsXuyiTDDT1eV13sKuYsOUioXkQweYTQIbgHkXPry9K7M+7cKtYHnSUPitVaLrXYB1jTkkYrw==",
       "dev": true
     },
     "emittery": {
@@ -28021,15 +28038,15 @@
       }
     },
     "eslint": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
-      "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.54.0.tgz",
+      "integrity": "sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.3",
-        "@eslint/js": "8.53.0",
+        "@eslint/js": "8.54.0",
         "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -32084,9 +32101,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
     "normalize-package-data": {
@@ -32238,12 +32255,12 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
       "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       }
@@ -32859,15 +32876,21 @@
       }
     },
     "postcss-load-config": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
-      "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
       "dev": true,
       "requires": {
-        "lilconfig": "^2.0.5",
-        "yaml": "^2.1.1"
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
       },
       "dependencies": {
+        "lilconfig": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
+          "integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
+          "dev": true
+        },
         "yaml": {
           "version": "2.3.4",
           "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
@@ -34474,9 +34497,9 @@
       "dev": true
     },
     "simple-git": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.20.0.tgz",
-      "integrity": "sha512-ozK8tl2hvLts8ijTs18iFruE+RoqmC/mqZhjs/+V7gS5W68JpJ3+FCTmLVqmR59MaUQ52MfGQuWsIqfsTbbJ0Q==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.21.0.tgz",
+      "integrity": "sha512-oTzw9248AF5bDTMk9MrxsRzEzivMlY+DWH0yWS4VYpMhNLhDWnN06pCtaUyPnqv/FpsdeNmRqmZugMABHRPdDA==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
@@ -35921,9 +35944,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
-      "integrity": "sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.12",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@newfold-labs/wp-module-ecommerce",
   "description": "Brand Agnostic eCommerce Experience",
   "license": "GPL-2.0-or-later",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "main": "build/index.js",
   "files": [
     "build/",

--- a/src/components/OnboardingScreen.js
+++ b/src/components/OnboardingScreen.js
@@ -1,13 +1,14 @@
-import { Alert, Button, Title } from '@newfold/ui-component-library';
-import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import classNames from 'classnames';
-import { ReactComponent as ComingSoonIllustration } from '../icons/coming-soon.svg';
-import { ReactComponent as WelcomeIllustration } from '../icons/store-live.svg';
-import { NewfoldRuntime } from '../sdk/NewfoldRuntime';
-import { OnboardingList } from './OnboardingList';
-import { Section } from './Section';
-import { SiteStatus } from './SiteStatus';
+import { Alert, Button, Title } from "@newfold/ui-component-library";
+import { useEffect, useState } from "@wordpress/element";
+import { __ } from "@wordpress/i18n";
+import classNames from "classnames";
+import { ReactComponent as ComingSoonIllustration } from "../icons/coming-soon.svg";
+import { ReactComponent as WelcomeIllustration } from "../icons/store-live.svg";
+import { NewfoldRuntime } from "../sdk/NewfoldRuntime";
+import { OnboardingList } from "./OnboardingList";
+import { Section } from "./Section";
+import { SiteStatus } from "./SiteStatus";
+import useThumbnail from "./useThumbnail";
 
 const Text = {
   Pending: {
@@ -16,7 +17,7 @@ const Text = {
       : __('Congrats on your new site!', 'wp-module-ecommerce'),
     description: __(
       'Your site is currently displaying a "Coming Soon" page.',
-      'wp-module-ecommerce'
+      "wp-module-ecommerce"
     ),
     Illustration: ComingSoonIllustration,
   },
@@ -38,6 +39,7 @@ export function OnboardingScreen({
     : Text.Live;
 
   const [hovered, setIsHovered] = useState(false);
+  const [thumbnail, setThumbnail] = useState();
 
   const handleMouseOver = () => {
     setIsHovered(true);
@@ -47,11 +49,10 @@ export function OnboardingScreen({
     setIsHovered(false);
   };
 
-  const iframeOnLoad = () => {
-    window.frames['iframe-preview'].document.getElementById(
-      'wpadminbar'
-    ).style.display = 'none';
-  };
+  useEffect(async () => {
+    const data = await useThumbnail(NewfoldRuntime.homeUrl);
+    setThumbnail(data?.thumbnail_loc);
+  }, []);
 
   return (
     <Section.Container
@@ -111,26 +112,26 @@ export function OnboardingScreen({
                   <div className="nfd-flex-col">
                     <div
                       className={classNames(
-                        'nfd-h-[216px] nfd-box-content',
-                        'nfd-box-content nfd-z-[2] nfd-opacity-100',
-                        'nfd-flex nfd-flex-col nfd-justify-center nfd-items-center',
-                        'md:nfd-w-[520px] md:min-[783px]:nfd-w-[387px] md:min-[768px]:nfd-w-[670px]',
-                        'lg:min-[1024px]:nfd-w-[486px] lg:nfd-w-[520px] lg:nfd-h-[258px]',
-                        'xl:min-[1280px]:nfd-w-[360px]',
-                        '2xl:nfd-w-[520px]'
+                        "nfd-h-[216px] nfd-box-content",
+                        "nfd-box-content nfd-z-[2] nfd-opacity-100",
+                        "nfd-flex nfd-flex-col nfd-justify-center nfd-items-center",
+                        "md:nfd-w-[520px] md:min-[783px]:nfd-w-[387px] md:min-[768px]:nfd-w-[670px]",
+                        "lg:min-[1024px]:nfd-w-[486px] lg:nfd-w-[520px] lg:nfd-h-[245px]",
+                        "xl:min-[1280px]:nfd-w-[360px]",
+                        "2xl:nfd-w-[520px]"
                       )}
                     >
-                      <iframe
-                        onLoad={iframeOnLoad}
-                        id="iframe-preview"
-                        title="Preview"
-                        className="nfd-w-[400%] nfd-min-h-[400%] nfd-basis-full nfd-scale-[0.25] nfd-overflow-hidden nfd-relative nfd-top-[-9px]"
-                        src={NewfoldRuntime.homeUrl}
-                        scrolling="no"
-                        name="iframe-preview"
-                        sandbox
-                        seamless
-                      ></iframe>
+                      {thumbnail ? (
+                        <img
+                          className="nfd-w-full nfd-h-full"
+                          src={thumbnail}
+                          alt="image not available"
+                        />
+                      ) : (
+                        <Illustration
+                          className={classNames("nfd-h-full", "nfd-w-full")}
+                        />
+                      )}
                     </div>
                   </div>
                 )}
@@ -142,7 +143,7 @@ export function OnboardingScreen({
                 >
                   <Button
                     style={{
-                      display: hovered ? 'block' : 'none',
+                      display: hovered ? "block" : "none",
                     }}
                     as="a"
                     className="nfd-bg-canvas "

--- a/src/components/useThumbnail.js
+++ b/src/components/useThumbnail.js
@@ -1,0 +1,24 @@
+const REACT_APP_THUMBNAIL_URL =
+  'https://thumbnail.uapi.newfold.com/v1/thumbnail/get-screenshot';
+
+const REACT_APP_THUMBNAIL_JWT =
+  'eyJhbGciOiJSUzI1NiIsImtpZCI6InRodW1ibmFpbCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1cm46amFydmlzOmJsdWVob3N0Iiwic2NvcGUiOiJ1c2VyLWZlIiwiYWN0Ijp7InN1YiI6ImphcnZpczpibHVlaG9zdDp1c2VyOnRlc3R1c2VyIiwicm9sZSI6ImFkbWluIn0sImF1ZCI6IlFBIiwiZXhwIjoxOTk2MTY4NDM2LCJpYXQiOjE2ODA1OTI0MzZ9.RDo_m2PP18ZAduFbCM1FVfDFpAh41785DtTkxRotN8qLcce95FZN8JkMiZdY7FOVzYLpAoY8bX6I8jcD7Libz1Q1Q02Qxy1vLX5-CUuwQ9VOioqs6637gBDspmO9ZjKj7Qy4DNnSzVW_e6qQQye9ZGDmeI1HsSm9LYhtTM6sPI7maSqMtCfCnJNJGHW0nO3AI1s4m11f6cxYHATypol6mNcVb1Jw7ex9e4-azWWOdESPotGxTJaA4kWDMrxIRR1Sg_0RLuurjvXMDLqCKarYGCH-JhDBIjyNS8j1ikTYY9rhPzim438u1Cp-txfPzMlopOSIW5zBuc5X7B9g2y8-TQ';
+
+const fetchThumbnail = async (siteUrl, override) => {
+  const result = await fetch(
+    `${REACT_APP_THUMBNAIL_URL}?site_url=${siteUrl}&force_override=${override}`,
+    {
+      headers: {
+        Authorization: `Bearer ${REACT_APP_THUMBNAIL_JWT}`,
+      },
+    }
+  );
+  return await result.json();
+};
+
+const useThumbnail = async (siteUrl, override = false) => {
+  const result = await fetchThumbnail(siteUrl, override);
+  return result;
+};
+
+export default useThumbnail;

--- a/src/configs/OnboardingList.config.js
+++ b/src/configs/OnboardingList.config.js
@@ -85,7 +85,7 @@ export function OnboardingListDefinition(props) {
         state: {
           isCompleted: (queries) => queries?.orders?.pendingOrders?.length < 1,
           isActive: (queries) =>  queries?.orders?.ordersCount > 0,
-          url: (queries) => queries?.orders?.pendingOrders?.length !== 1 ? `${NewfoldRuntime.siteDetails?.url}/wp-admin/edit.php?post_type=shop_order` : `${NewfoldRuntime.siteDetails?.url}/wp-admin/post.php?post=${queries?.orders?.pendingOrders[0]?.id}&action=edit`
+          url: (queries) => queries?.orders?.pendingOrders?.length !== 1 ? `${RuntimeSdk.adminUrl('edit.php?post_type=shop_order')}` : RuntimeSdk.adminUrl(`post.php?post=${queries?.orders?.pendingOrders[0]?.id}&action=edit`)
         },
         shouldRender: (state) => NewfoldRuntime.isWoo && state.isActive,
         actions: {


### PR DESCRIPTION
Jira Link: https://jira.newfold.com/browse/PRESS4-390

Updating woocommerce_task_list_hidden_lists option in database on before_woocommerce_init hook

Description:
Given WooCommerce has just been activated
When the customer visits the WooCommerce page
Then they will not see the setup list

![image](https://github.com/newfold-labs/wp-module-ecommerce/assets/149479917/5ba7dc69-83cd-492f-896f-acacbbf10403)

##
Jira Link: https://jira.newfold.com/browse/PRESS4-399
Removed the Adminbar from Iframe for site view

![image](https://github.com/newfold-labs/wp-module-ecommerce/assets/149479917/2f8d73ae-db7a-47e0-a257-f2294b182aee)

##
Version bump to 1.3.13

