### PR TITLE
Bump onboarding-data to 0.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   ],
   "require": {
     "newfold-labs/wp-module-installer": "^1.1",
-    "newfold-labs/wp-module-onboarding-data": "^0.0"
+    "newfold-labs/wp-module-onboarding-data": "^0.1"
   },
   "require-dev": {
     "newfold-labs/wp-php-standards": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,70 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "384f77b7af2a01bf6cdfaf061a78f7b7",
+    "content-hash": "5742e827dea87d677914faff3b1b0a94",
     "packages": [
         {
-            "name": "newfold-labs/wp-module-data",
-            "version": "2.4.15",
+            "name": "newfold-labs/wp-module-coming-soon",
+            "version": "1.1.13",
             "source": {
                 "type": "git",
-                "url": "https://github.com/newfold-labs/wp-module-data.git",
-                "reference": "1bfc538c2f7c282175ddcd9b4513bcbe85facbbe"
+                "url": "https://github.com/newfold-labs/wp-module-coming-soon.git",
+                "reference": "9719bae8534e6c86d389b769a1757eceed5f1dd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/1bfc538c2f7c282175ddcd9b4513bcbe85facbbe",
-                "reference": "1bfc538c2f7c282175ddcd9b4513bcbe85facbbe",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-coming-soon/zipball/9719bae8534e6c86d389b769a1757eceed5f1dd5",
+                "reference": "9719bae8534e6c86d389b769a1757eceed5f1dd5",
+                "shasum": ""
+            },
+            "require-dev": {
+                "newfold-labs/wp-php-standards": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "NewfoldLabs\\WP\\Module\\ComingSoon\\": "includes"
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "scripts": {
+                "fix": [
+                    "vendor/bin/phpcbf . --standard=phpcs.xml"
+                ],
+                "lint": [
+                    "vendor/bin/phpcs . --standard=phpcs.xml -s"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Evan Mullins",
+                    "homepage": "https://evanmullins.com"
+                }
+            ],
+            "description": "Coming Soon module for WordPress sites.",
+            "support": {
+                "source": "https://github.com/newfold-labs/wp-module-coming-soon/tree/1.1.13",
+                "issues": "https://github.com/newfold-labs/wp-module-coming-soon/issues"
+            },
+            "time": "2024-01-08T18:13:10+00:00"
+        },
+        {
+            "name": "newfold-labs/wp-module-data",
+            "version": "2.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/newfold-labs/wp-module-data.git",
+                "reference": "633712f1d717c564f62bd6cfc4e70d56959d8a22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/633712f1d717c564f62bd6cfc4e70d56959d8a22",
+                "reference": "633712f1d717c564f62bd6cfc4e70d56959d8a22",
                 "shasum": ""
             },
             "require": {
@@ -50,10 +100,10 @@
             ],
             "description": "Newfold Data Module",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.4.15",
+                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.4.16",
                 "issues": "https://github.com/newfold-labs/wp-module-data/issues"
             },
-            "time": "2023-12-12T21:28:52+00:00"
+            "time": "2024-01-08T20:37:18+00:00"
         },
         {
             "name": "newfold-labs/wp-module-installer",
@@ -99,20 +149,21 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",
-            "version": "0.0.9",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding-data.git",
-                "reference": "fddabb8dbdd8a717f6efb215d3a1f47d7ecd7c43"
+                "reference": "ebe0ef43930b7bf86dac7f6dc12fb9d6d4c962c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/fddabb8dbdd8a717f6efb215d3a1f47d7ecd7c43",
-                "reference": "fddabb8dbdd8a717f6efb215d3a1f47d7ecd7c43",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/ebe0ef43930b7bf86dac7f6dc12fb9d6d4c962c6",
+                "reference": "ebe0ef43930b7bf86dac7f6dc12fb9d6d4c962c6",
                 "shasum": ""
             },
             "require": {
-                "newfold-labs/wp-module-data": "^2.4.3",
+                "newfold-labs/wp-module-coming-soon": "^1.1.13",
+                "newfold-labs/wp-module-data": "^2.4.16",
                 "newfold-labs/wp-module-installer": "^1.1",
                 "wp-forge/wp-upgrade-handler": "^1.0"
             },
@@ -133,10 +184,10 @@
             ],
             "description": "A non-toggleable module containing a standardized interface for interacting with Onboarding data.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/0.0.9",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/0.1.0",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding-data/issues"
             },
-            "time": "2023-12-08T20:29:27+00:00"
+            "time": "2024-01-11T09:45:56+00:00"
         },
         {
             "name": "wp-forge/wp-query-builder",
@@ -4632,5 +4683,5 @@
     "platform-overrides": {
         "php": "7.0.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This update prevents conflict with the onboarding module that was recently bumped to 1.12.0. I did not notice any breaking changes as such.