### PR TITLE
Added 'edit site' to preview hover

### DIFF
--- a/src/components/OnboardingScreen.js
+++ b/src/components/OnboardingScreen.js
@@ -5,6 +5,7 @@ import classNames from "classnames";
 import { ReactComponent as ComingSoonIllustration } from "../icons/coming-soon.svg";
 import { ReactComponent as WelcomeIllustration } from "../icons/store-live.svg";
 import { NewfoldRuntime } from "../sdk/NewfoldRuntime";
+import { RuntimeSdk } from "../sdk/runtime";
 import { OnboardingList } from "./OnboardingList";
 import { Section } from "./Section";
 import { SiteStatus } from "./SiteStatus";
@@ -134,13 +135,13 @@ export function OnboardingScreen({
                 )}
                 <div
                   className={classNames(
-                    "nfd-absolute nfd-top-0 nfd-left-0 nfd-bottom-0 nfd-right-0 nfd-place-content-center nfd-grid",
+                    "nfd-absolute nfd-top-0 nfd-left-0 nfd-bottom-0 nfd-right-0 nfd-flex nfd-items-center nfd-justify-center nfd-gap-4 nfd-flex-col ",
                     "hover:nfd-animate-[wiggle_1s_ease-in-out_infinite]"
                   )}
                 >
                   <Button
                     style={{
-                      display: hovered ? "block" : "none",
+                      display: hovered ? "inline-block" : "none",
                     }}
                     as="a"
                     className="nfd-bg-canvas "
@@ -149,6 +150,18 @@ export function OnboardingScreen({
                     variant="secondary"
                   >
                     {__("View your site", "wp-module-ecommerce")}
+                  </Button>
+                  <Button
+                    style={{
+                      display: hovered ? "inline-block" : "none",
+                    }}
+                    as="a"
+                    className="nfd-bg-canvas "
+                    href={RuntimeSdk.adminUrl('site-editor.php?postType=wp_template&postId='+NewfoldRuntime.currentTheme+'//home')}
+                    target="_blank"
+                    variant="secondary"
+                  >
+                    {__("Edit your site", "wp-module-ecommerce")}
                   </Button>
                 </div>
               </div>

--- a/src/sdk/NewfoldRuntime.js
+++ b/src/sdk/NewfoldRuntime.js
@@ -28,5 +28,8 @@ export const NewfoldRuntime = {
   },
   get homeUrl(){
     return window.NewfoldRuntime?.homeUrl
+  },
+  get currentTheme(){
+    return (window.NewfoldRuntime?.currentTheme).toLowerCase().replace(/[\s-]+/g, '');
   }
 };


### PR DESCRIPTION
Added 'Edit your site' button on hover of site preview.
Ticket: https://jira.newfold.com/browse/PRESS4-455

Added code to get the current theme to runtime. 
PR: https://github.com/newfold-labs/wp-module-runtime/pull/18

![image](https://github.com/newfold-labs/wp-module-ecommerce/assets/149479917/b09137c5-de8e-46e5-8b71-73f721e760b6)
