### PR TITLE
Fix failing test

### DIFF
--- a/tests/cypress/integration/Home/commerceHomePage.cy.js
+++ b/tests/cypress/integration/Home/commerceHomePage.cy.js
@@ -46,7 +46,7 @@ describe("Commerce Home Page- Coming soon mode", () => {
       .should("exist");
     cy.get("@sitePreviewFlex")
       .trigger("mouseover")
-      .find("a.nfd-button")
+      .find("a.nfd-button:first-child")
       .should("have.text", "View your site")
       .invoke("removeAttr", "target")
       .click();


### PR DESCRIPTION
This updates a failing test so that it will pass. Update selector in test so only the expected button is returned.

While this should fix the test, I see some improvements that can be made to make the test more robust and less likely to fail in the future. Currently, the selector is getting two buttons and checking if the text matches the first. The changes the selector to only get the first button so when it checks the button text it will find a match.

Ideally, we should add a unique id attribute (or better yet, a data-cy attribute) to the elements on the components so that we can select them easily in the test. Here's more on this: https://docs.cypress.io/guides/references/best-practices#Selecting-Elements

In this case, we should probably just check that the button exists, since the text is translatable. We don't want to be locked into content for the test to pass.

To implement it all we'd add the data-cy attribute 'view-site' to the button in question and then
```
.find("a.nfd-button:first-child").should("have.text", "View your site")
```
Becomes 
```
.find('a[data-cy="view-site"]).should("exist")
```

There are a lot of places this can be implemented to help the tests be more robust and reliable over time.