### PR TITLE
PRESS4-475 | Remove Creative Mail banner from branded plugin

### DIFF
--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => 'c3f16f7961a01916c59e');
+<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => '6307329585bdd0c557f9');

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -91,6 +91,7 @@ class ECommerce {
 		add_action('woocommerce_admin_order_data_after_shipping_address', array( $this, 'display_custom_shipping_fields_in_admin' ), 10, 1 );
 		add_action( 'before_woocommerce_init', array( $this,'custom_payment_gateways_order'));
 		add_action('before_woocommerce_init', array( $this,'dismiss_woo_payments_cta'));
+		add_action( 'load-toplevel_page_'. $container->plugin()->id, array( $this, 'disable_creative_mail_banner' ) );
 
 		// Handle WonderCart Integrations
 		if ( is_plugin_active( 'wonder-cart/init.php' ) ) {
@@ -433,6 +434,13 @@ class ECommerce {
 		$is_dismissed = get_option( 'wcpay_welcome_page_incentives_dismissed');
 		if (!is_array($is_dismissed) || empty($is_dismissed)) {
 			update_option('wcpay_welcome_page_incentives_dismissed', array("wcpay-promo-2023-action-discount"));
+		}
+	}
+
+	public function disable_creative_mail_banner() {
+		$is_dismissed = get_option( 'ce4wp_ignore_review_notice');
+		if (!is_array($is_dismissed) || empty($is_dismissed)) {
+			update_option('ce4wp_ignore_review_notice', true);
 		}
 	}
 	


### PR DESCRIPTION
### Before Changes
<img width="1723" alt="Screenshot 2024-02-15 at 4 02 03 PM" src="https://github.com/newfold-labs/wp-module-ecommerce/assets/80672694/20b8debc-8e5b-4f06-9994-c3b111966070">


### After changes
<img width="1723" alt="Screenshot 2024-02-15 at 3 57 26 PM" src="https://github.com/newfold-labs/wp-module-ecommerce/assets/80672694/30963d79-f2c3-4cb1-8d2b-5ffe9875af95">

### Changes requested
Remove the creative mail notice that shows after one week of download the plugin. 

### **Changes Done**
updating the **ce4wp_ignore_review_notice** value in db to hide the banner