### PR TITLE
PRESS4-484 | Edit site redirect to page editor

### DIFF
--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => 'c3f16f7961a01916c59e');
+<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => '2594edd0d7eff5838e6c');

--- a/src/components/OnboardingScreen.js
+++ b/src/components/OnboardingScreen.js
@@ -1,5 +1,5 @@
 import { Alert, Button, Title } from "@newfold/ui-component-library";
-import { useState } from "@wordpress/element";
+import { useEffect, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import classNames from "classnames";
 import { ReactComponent as ComingSoonIllustration } from "../icons/coming-soon.svg";
@@ -9,6 +9,7 @@ import { RuntimeSdk } from "../sdk/runtime";
 import { OnboardingList } from "./OnboardingList";
 import { Section } from "./Section";
 import { SiteStatus } from "./SiteStatus";
+import { WordPressSdk } from "../sdk/wordpress";
 
 const Text = {
   Pending: {
@@ -39,6 +40,7 @@ export function OnboardingScreen({
     : Text.Live;
 
   const [hovered, setIsHovered] = useState(false);
+  const [editUrl, setEditUrl] = useState('');
 
   const handleMouseOver = () => {
     setIsHovered(true);
@@ -52,6 +54,17 @@ export function OnboardingScreen({
       "wpadminbar"
     ).style.display = "none";
   };
+
+  useEffect(() => {
+    WordPressSdk.settings.get().then(res => {
+      if(res?.page_on_front && res?.show_on_front === 'page'){
+        setEditUrl(RuntimeSdk.adminUrl(`post.php?post=${res?.page_on_front}&action=edit`, false))
+      }else{
+        setEditUrl(RuntimeSdk.adminUrl('site-editor.php?canvas=edit'));
+      }
+    })
+  }, [])
+
   return (
     <Section.Container
       className="nfd-welcome-section"
@@ -158,7 +171,7 @@ export function OnboardingScreen({
                     }}
                     as="a"
                     className="nfd-bg-canvas "
-                    href={RuntimeSdk.adminUrl('site-editor.php?postType=wp_template&postId='+NewfoldRuntime.currentTheme+'//home')}
+                    href={editUrl}
                     target="_blank"
                     variant="secondary"
                     data-cy="edit-site"


### PR DESCRIPTION
###  Homepage is set

<img width="1093" alt="Screenshot 2024-02-20 at 2 43 57 PM" src="https://github.com/newfold-labs/wp-module-ecommerce/assets/80672694/b3720851-f3a7-4776-a861-a2e40ecb47b4">

### Homepage is not set
<img width="1093" alt="Screenshot 2024-02-20 at 2 46 56 PM" src="https://github.com/newfold-labs/wp-module-ecommerce/assets/80672694/258e4d8f-f578-49ed-810b-76c8393f0185">

###
**Changes**
When homepage is set in wordpress, edit site should redirect to homepage editor and if it is not set, it should be redirected to site editor.
