### PR TITLE
Press4 462 | Adding CTB to Yith products

### DIFF
--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => 'c75bacc2c8722d4a5390');
+<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => '9fc42ea5420f48b85177');

--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => 'c3f16f7961a01916c59e');
+<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => '41b304f1760c9b854317');

--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,2 +1,1 @@
-<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => '11bfde3e6f52de3d50f6');
-
+<?php return array('dependencies' => array('lodash', 'moment', 'react', 'wp-api-fetch', 'wp-data', 'wp-date', 'wp-dom-ready', 'wp-element', 'wp-i18n', 'wp-url'), 'version' => 'c75bacc2c8722d4a5390');

--- a/src/components/FeatureCard.js
+++ b/src/components/FeatureCard.js
@@ -90,7 +90,7 @@ export function FeatureCard({ state, actions, assets, text, ...props }) {
             as="a"
             target="_blank"
             data-action="load-nfd-ctb"
-            data-ctb-id={state.upsellOptions.clickToBuyId}
+            data-ctb-id={state?.upsellOptions?.clickToBuyId}
             href={state.upsellOptions?.primaryUrl}
           >
             <span>{__("Purchase", "wp-module-ecommerce")}</span>

--- a/src/components/FeatureCard.js
+++ b/src/components/FeatureCard.js
@@ -93,7 +93,7 @@ export function FeatureCard({ state, actions, assets, text, ...props }) {
             data-ctb-id={state?.upsellOptions?.clickToBuyId}
             href={state.upsellOptions?.primaryUrl}
           >
-            <span>{__("Purchase", "wp-module-ecommerce")}</span>
+            {__("Purchase", "wp-module-ecommerce")}
             {ActionIcon && !isInstalling ? <ArrowLongRightIcon /> : null}
           </Button>
         </Card.Footer>

--- a/src/components/FeatureCard.js
+++ b/src/components/FeatureCard.js
@@ -50,7 +50,11 @@ export function FeatureCard({ state, actions, assets, text, ...props }) {
             className="nfd-flex nfd-mt-4 nfd-items-center nfd-gap-2 nfd-no-underline"
             href={learnMoreUrl}
             target="_blank"
-            onClick={() => AnalyticsSdk.track( "commerce", title, {value: 'clicked on the learn more url'} )}
+            onClick={() =>
+              AnalyticsSdk.track("commerce", title, {
+                value: "clicked on the learn more url",
+              })
+            }
           >
             <span>{__("Learn More", "wp-module-ecommerce")}</span>
             <ArrowLongRightIcon className="nfd-h-5 nfd-text-black" />
@@ -85,12 +89,8 @@ export function FeatureCard({ state, actions, assets, text, ...props }) {
             variant="upsell"
             as="a"
             target="_blank"
-            {...(state.upsellOptions?.clickToBuyId
-              ? {
-                  "data-action": "load-nfd-ctb",
-                  "data-ctb-id": state.upsellOptions.clickToBuyId,
-                }
-              : {})}
+            data-action="load-nfd-ctb"
+            data-ctb-id={state.upsellOptions.clickToBuyId}
             href={state.upsellOptions?.primaryUrl}
           >
             <span>{__("Purchase", "wp-module-ecommerce")}</span>

--- a/src/components/YithFeatureCard.js
+++ b/src/components/YithFeatureCard.js
@@ -72,8 +72,8 @@ export function YithFeatureCard({
               variant="upsell"
               as="a"
               target="_blank"
-              data-ctb-id={clickToBuyId}
               data-action="load-nfd-ctb"
+              data-ctb-id={clickToBuyId}
               href={primaryUrl}
             >
               {__("Purchase", "wp-module-ecommerce")}

--- a/src/components/YithFeatureCard.js
+++ b/src/components/YithFeatureCard.js
@@ -66,17 +66,29 @@ export function YithFeatureCard({
         </Card.Footer>
       ) : state?.isUpsellNeeded ? (
         <Card.Footer>
-          <Button
-            className="nfd-w-full nfd-h-9 nfd-border nfd-flex nfd-items-center nfd-gap-2"
-            variant="upsell"
-            as="a"
-            target="_blank"
-            data-ctb-id={clickToBuyId}
-            data-action="load-nfd-ctb"
-            href={primaryUrl}
-          >
-            {__("Purchase", "wp-module-ecommerce")}
-          </Button>
+          {id !== "e307cb8f-24b5-46e1-81e3-83de32c62c78" ? (
+            <Button
+              className="nfd-w-full nfd-h-9 nfd-border nfd-flex nfd-items-center nfd-gap-2"
+              variant="upsell"
+              as="a"
+              target="_blank"
+              data-ctb-id={clickToBuyId}
+              data-action="load-nfd-ctb"
+              href={primaryUrl}
+            >
+              {__("Purchase", "wp-module-ecommerce")}
+            </Button>
+          ) : (
+            <Button
+              className="nfd-w-full nfd-h-9 nfd-border nfd-flex nfd-items-center nfd-gap-2"
+              variant="upsell"
+              as="a"
+              target="_blank"
+              href={primaryUrl}
+            >
+              {__("Purchase", "wp-module-ecommerce")}
+            </Button>
+          )}
         </Card.Footer>
       ) : (
         <Card.Footer>

--- a/src/components/YithFeatureCard.js
+++ b/src/components/YithFeatureCard.js
@@ -59,8 +59,6 @@ export function YithFeatureCard({
             className="nfd-w-full nfd-h-9 nfd-border nfd-flex nfd-items-center nfd-gap-2"
             variant="secondary"
             as="a"
-            data-ctb-id={clickToBuyId}
-            data-action="load-nfd-ctb"
             href={state?.featureUrl}
           >
             <span>{state?.isActive ? __("Manage") : __("Enable")}</span>
@@ -75,15 +73,9 @@ export function YithFeatureCard({
             target="_blank"
             data-ctb-id={clickToBuyId}
             data-action="load-nfd-ctb"
-            // {...(state?.upsellOptions?.clickToBuyId
-            //   ? {
-            //       "data-action": "load-nfd-ctb",
-            //       "data-ctb-id": state?.upsellOptions.clickToBuyId,
-            //     }
-            //   : {})}
             href={primaryUrl}
           >
-            <span>{__("Purchase", "wp-module-ecommerce")}</span>
+            {__("Purchase", "wp-module-ecommerce")}
           </Button>
         </Card.Footer>
       ) : (

--- a/src/components/YithFeatureCard.js
+++ b/src/components/YithFeatureCard.js
@@ -4,11 +4,11 @@ import { AnalyticsSdk } from "../sdk/analytics";
 import { ArrowLongRightIcon } from "@heroicons/react/20/solid";
 
 export function YithFeatureCard({
-  yithProducts: { name, description, primaryUrl },
+  yithProducts: { name, description, primaryUrl, clickToBuyId },
   yithPluginsMap,
   id,
   cards,
-  }) {
+}) {
   const cardsInfo = cards.filter(
     (card) => card.name === yithPluginsMap.get(id).title
   )[0];
@@ -59,6 +59,8 @@ export function YithFeatureCard({
             className="nfd-w-full nfd-h-9 nfd-border nfd-flex nfd-items-center nfd-gap-2"
             variant="secondary"
             as="a"
+            data-ctb-id={clickToBuyId}
+            data-action="load-nfd-ctb"
             href={state?.featureUrl}
           >
             <span>{state?.isActive ? __("Manage") : __("Enable")}</span>
@@ -71,12 +73,14 @@ export function YithFeatureCard({
             variant="upsell"
             as="a"
             target="_blank"
-            {...(state?.upsellOptions?.clickToBuyId
-              ? {
-                  "data-action": "load-nfd-ctb",
-                  "data-ctb-id": state?.upsellOptions.clickToBuyId,
-                }
-              : {})}
+            data-ctb-id={clickToBuyId}
+            data-action="load-nfd-ctb"
+            // {...(state?.upsellOptions?.clickToBuyId
+            //   ? {
+            //       "data-action": "load-nfd-ctb",
+            //       "data-ctb-id": state?.upsellOptions.clickToBuyId,
+            //     }
+            //   : {})}
             href={primaryUrl}
           >
             <span>{__("Purchase", "wp-module-ecommerce")}</span>

--- a/src/sdk/marketplace.js
+++ b/src/sdk/marketplace.js
@@ -26,7 +26,7 @@ export const MarketplaceSdk = {
           product.type === "plugin"
       )
       .map((product) => ({
-        clickToBuyId: ctbIsSupported ? product.clickToBuyId : null,
+        clickToBuyId: product.clickToBuyId,
         name: product.name,
         primaryUrl: product.primaryUrl,
       }));


### PR DESCRIPTION
Currently in the branded plugin, we are redirecting customers to the YITH plugin pages to purchase premium plugins. We need to use the YITH CTBs instead.
https://confluence.newfold.com/display/SF/Yith+Plugins

story : https://jira.newfold.com/browse/PRESS4-462