### PR TITLE
Fix Cypress tests locally

### DIFF
--- a/tests/cypress/integration/Home/commerceHomePage.cy.js
+++ b/tests/cypress/integration/Home/commerceHomePage.cy.js
@@ -6,7 +6,7 @@ import {
 } from '../wp-module-support/utils.cy';
 import { EventsAPI, APIList } from '../wp-module-support/eventsAPIs.cy';
 
-const customCommandTimeout = 60000;
+const customCommandTimeout = 20000;
 const pluginId = GetPluginId();
 const hg_region = 'br';
 
@@ -132,14 +132,10 @@ describe( 'Commerce Home Page- Next Steps', () => {
 			failOnNonZeroExit: false,
 		} );
 
+		cy.exec(`npx wp-env run cli wp option set mm_brand ${ pluginId }`);
+
 		if ( pluginId == 'hostgator' ) {
-			cy.exec( `npx wp-env run cli wp option delete mm_brand` );
-			cy.exec(
-				`npx wp-env run cli wp option set mm_brand ${ pluginId }`
-			);
-			cy.exec(
-				`npx wp-env run cli wp option set hg_region ${ hg_region }}`
-			);
+			cy.exec(`npx wp-env run cli wp option set hg_region ${ hg_region }`);
 		}
 	} );
 


### PR DESCRIPTION
- One `cy.exec` command was failing due to an additional closing brace.
- We were deleting `mm_brand` then setting `mm_brand`, so I removed the delete.
- We were conditionally setting `mm_brand` to the plugin ID, but we should always do that.
- Reduce from a 60-second timeout to a 20-second timeout. In the event of a failure, this reduces wait time by 1/3 and speeds up test runs overall.