### PR TITLE
Fix Cannot modify header information warning due to  PRESS4-508 code …

### DIFF
--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -193,10 +193,10 @@ class ECommerce {
 	 */
 	public static function set_wpnav_collapse_setting( $brandNameValue ) {
 
-		$expiration_time = time() + ( 10 * 365 * 24 * 60 * 60 );
-		setcookie( 'nfdbrandname', $brandNameValue, $expiration_time, '/' );
-
 		wp_enqueue_script( 'nfd_wpnavbar_setting', NFD_ECOMMERCE_PLUGIN_URL . 'vendor/newfold-labs/wp-module-ecommerce/includes/wpnavbar.js', array( 'jquery' ), '1.0', true );
+		$params = array('nfdbrandname' => $brandNameValue);
+		wp_localize_script( 'nfd_wpnavbar_setting', 'navBarParams', $params );
+
 	}
 
 	/**

--- a/includes/wpnavbar.js
+++ b/includes/wpnavbar.js
@@ -1,7 +1,7 @@
 
 document.addEventListener('DOMContentLoaded', function() {
 
-    let brandCookie = "?page="+getCookie('nfdbrandname');
+    let brandCookie = "?page="+navBarParams.nfdbrandname;
     let urlSearchString = window.location.search;
 
     


### PR DESCRIPTION
## Proposed changes

Fix for PHP Warning:  Cannot modify header information - headers already sent in /Users/arati.b/Desktop/wp-module-ecommerce/includes/ECommerce.php on line 197 due to PRESS4-508 code changes.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
