### PR TITLE
Press0-1119 | Press0-1141

### DIFF
--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -100,9 +100,8 @@ class ECommerce {
 		add_action( 'manage_posts_custom_column', array( $this, 'custom_status_column_content' ), 10, 2 );
 		add_filter( 'manage_pages_columns', array( $this, 'custom_status_column' ), 10, 1 );
 		add_action( 'manage_pages_custom_column', array( $this, 'custom_status_column_content' ), 10, 2 );
-		add_filter( 'manage_edit-product_sortable_columns', array( $this, 'sortable_product_columns' ) );
-		add_filter( 'manage_edit-post_sortable_columns', array( $this, 'sortable_product_columns' ) );
-		add_filter( 'manage_edit-page_sortable_columns', array( $this, 'sortable_product_columns' ) );
+		add_filter( 'manage_edit-post_sortable_columns', array( $this, 'sortable_columns' ) );
+		add_filter( 'manage_edit-page_sortable_columns', array( $this, 'sortable_columns' ) );
 
 		$brandNameValue = $container->plugin()->brand;
 		$this->set_wpnav_collapse_setting( $brandNameValue );
@@ -553,30 +552,32 @@ class ECommerce {
 
 	/**
 	 * Hide Most columns by default
-	 * Shows title and date in the page/post/product screen by default
+	 * Shows title and date in the page/post screen by default
 	 *
 	 * @return void
 	 */
 	public function hide_columns() {
-		if ( ! get_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden' ) ) {
-			update_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden', array( 'author', 'comments', 'date' ) );
+		if( 1 === get_option( 'onboarding_experience_level' ) ) {
+			if ( ! get_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden' ) ) {
+				update_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden', array( 'author', 'comments', 'date' ) );
+			}
+			if ( ! get_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden' ) ) {
+				update_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden', array( 'author', 'categories', 'tags', 'comments', 'date' ) );
+			}
 		}
-		if ( ! get_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden' ) ) {
-			update_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden', array( 'author', 'categories', 'tags', 'comments', 'date' ) );
-		}
-		if ( ! get_user_meta( get_current_user_id(), 'manageedit-productcolumnshidden' ) ) {
-			update_user_meta( get_current_user_id(), 'manageedit-productcolumnshidden', array( 'sku', 'stock', 'date' ) );
-		}
+		
 	}
 
 	/**
 	 * Add custom column header for post/page/product screen
 	 *
-	 * @param array $columns Array of column names for posts/pages/products
+	 * @param array $columns Array of column names for posts/pages
 	 */
 	public function custom_status_column( $columns ) {
-		// Add 'Status' column after 'Title'
-		$columns['status'] = 'Status';
+		if ( 'product' != get_post_type() && 1 === get_option( 'onboarding_experience_level' ) ) {
+			// Add 'Status' column after 'Title'
+			$columns['status'] = 'Status';
+		}
 		return $columns;
 	}
 
@@ -585,7 +586,7 @@ class ECommerce {
 	 *
 	 * @param string $column_name column names to which content needs to be updated
 	 *
-	 * @param int    $post_id Id of post/page/product
+	 * @param int    $post_id Id of post/page
 	 */
 	public function custom_status_column_content( $column_name, $post_id ) {
 		if ( 'status' === $column_name ) {
@@ -619,9 +620,9 @@ class ECommerce {
 	/**
 	 * Add sorting for the status column
 	 *
-	 * @param array $columns Array of column names for posts/pages/products
+	 * @param array $columns Array of sortable column names for posts/pages
 	 */
-	public function sortable_product_columns( $columns ) {
+	public function sortable_columns( $columns ) {
 		$columns['status'] = 'status';
 		return $columns;
 	}

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -95,7 +95,7 @@ class ECommerce {
 		add_action( 'before_woocommerce_init', array( $this, 'dismiss_woo_payments_cta' ) );
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'disable_creative_mail_banner' ) );
 		add_action( 'activated_plugin', array( $this, 'detect_plugin_activation' ), 10, 1 );
-		add_action( 'wp_footer', array( $this, 'hide_columns' ) );
+		add_action( 'admin_init', array( $this, 'hide_columns' ) );
 		add_filter( 'manage_posts_columns', array( $this, 'custom_status_column' ), 10, 1 );
 		add_action( 'manage_posts_custom_column', array( $this, 'custom_status_column_content' ), 10, 2 );
 		add_filter( 'manage_pages_columns', array( $this, 'custom_status_column' ), 10, 1 );

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -557,7 +557,7 @@ class ECommerce {
 	 * @return void
 	 */
 	public function hide_columns() {
-		if( 1 == get_option( 'onboarding_experience_level' ) ) {
+		if ( 1 == get_option( 'onboarding_experience_level' ) ) {
 			if ( ! get_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden' ) ) {
 				update_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden', array( 'author', 'comments', 'date', 'wpseo-score', 'wpseo-score-readability', 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw', 'wpseo-links' ) );
 			}
@@ -565,7 +565,6 @@ class ECommerce {
 				update_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden', array( 'author', 'categories', 'tags', 'comments', 'date', 'wpseo-score', 'wpseo-score-readability', 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw', 'wpseo-links' ) );
 			}
 		}
-		
 	}
 
 	/**
@@ -576,7 +575,7 @@ class ECommerce {
 	public function custom_status_column( $columns ) {
 		if ( 'product' != get_post_type() && 1 == get_option( 'onboarding_experience_level' ) ) {
 			// Add 'Status' column after 'Title'
-			$columns['status'] = 'Status';
+			$columns['status'] = __( 'Status', 'wp-module-ecommerce' );
 		}
 		return $columns;
 	}
@@ -589,7 +588,7 @@ class ECommerce {
 	 * @param int    $post_id Id of post/page
 	 */
 	public function custom_status_column_content( $column_name, $post_id ) {
-		if ( 'status' === $column_name ) {
+		if ( __( 'Status', 'wp-module-ecommerce' ) === $column_name ) {
 			// Get the post status
 			$post_status = get_post_status( $post_id );
 			// Get the post date
@@ -600,7 +599,7 @@ class ECommerce {
 			$common_style = 'height: 24px; border-radius: 13px 13px 13px 13px;  gap: 16px; padding: 5px 10px; font-weight: 590;font-size: 12px;';
 			if ( 'publish' === $post_status ) {
 				$background_color = empty( $post_visibility ) ? '#C6E8CA' : '#FDE5CC';
-				$label_text       = empty( $post_visibility ) ? 'Published - Public' : 'Published - Password Protected';
+				$label_text       = empty( $post_visibility ) ? __( 'Published - Public', 'wp-module-ecommerce' ) : __( 'Published - Password Protected', 'wp-module-ecommerce' );
 			} elseif ( 'private' === $post_status ) {
 				$background_color = '#CCDCF4';
 				$label_text       = 'Published - Private';
@@ -613,7 +612,7 @@ class ECommerce {
 			if ( $coming_soon ) {
 				$background_color = '#E8ECF0';
 			}
-			echo '<span style="background-color: ' . $background_color . '; ' . $common_style . '">' . $label_text . '</span><br> Last Modified: ' . mysql2date( 'Y/m/d \a\t g:i a', $post_date );
+			echo '<span style="background-color: ' . $background_color . '; ' . $common_style . '">' . $label_text . '</span><br>' . __( 'Last Modified', 'wp-module-ecommerce' ) . ' : ' . mysql2date( 'Y/m/d \a\t g:i a', $post_date );
 		}
 	}
 

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -557,7 +557,7 @@ class ECommerce {
 	 * @return void
 	 */
 	public function hide_columns() {
-		if( 1 === get_option( 'onboarding_experience_level' ) ) {
+		if( 1 == get_option( 'onboarding_experience_level' ) ) {
 			if ( ! get_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden' ) ) {
 				update_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden', array( 'author', 'comments', 'date' ) );
 			}

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -559,10 +559,10 @@ class ECommerce {
 	public function hide_columns() {
 		if( 1 == get_option( 'onboarding_experience_level' ) ) {
 			if ( ! get_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden' ) ) {
-				update_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden', array( 'author', 'comments', 'date' ) );
+				update_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden', array( 'author', 'comments', 'date', 'wpseo-score', 'wpseo-score-readability', 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw', 'wpseo-links' ) );
 			}
 			if ( ! get_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden' ) ) {
-				update_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden', array( 'author', 'categories', 'tags', 'comments', 'date' ) );
+				update_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden', array( 'author', 'categories', 'tags', 'comments', 'date', 'wpseo-score', 'wpseo-score-readability', 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw', 'wpseo-links' ) );
 			}
 		}
 		

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -95,11 +95,11 @@ class ECommerce {
 		add_action( 'before_woocommerce_init', array( $this, 'dismiss_woo_payments_cta' ) );
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'disable_creative_mail_banner' ) );
 		add_action( 'activated_plugin', array( $this, 'detect_plugin_activation' ), 10, 1 );
-		add_action( 'admin_init', array( $this, 'hide_page_columns' ) );
-		add_filter('manage_posts_columns', array($this, 'custom_posts_columns'), 10, 1);
-		add_action('manage_posts_custom_column', array($this, 'custom_posts_column_content'), 10, 2);
-		add_filter('manage_pages_columns', array( $this,'custom_posts_columns'), 10, 1 );
-		add_action('manage_pages_custom_column', array($this, 'custom_posts_column_content'), 10, 2);
+		add_action( 'admin_init', array( $this, 'hide_columns' ) );
+		add_filter('manage_posts_columns', array($this, 'custom_status_column'), 10, 1);
+		add_action('manage_posts_custom_column', array($this, 'custom_status_column_content'), 10, 2);
+		add_filter('manage_pages_columns', array( $this,'custom_status_column'), 10, 1 );
+		add_action('manage_pages_custom_column', array($this, 'custom_status_column_content'), 10, 2);
 		add_filter('manage_edit-product_sortable_columns', array($this, 'sortable_product_columns'));
 		add_filter('manage_edit-post_sortable_columns', array($this, 'sortable_product_columns'));
 		add_filter('manage_edit-page_sortable_columns', array($this, 'sortable_product_columns'));
@@ -553,11 +553,12 @@ class ECommerce {
 	}
 
 	/**
-	 * Shows title and date in the page/post screen by default
+	 * Hide Most columns by default
+	 * Shows title and date in the page/post/product screen by default
      *
      * @return void
      */
-	public function hide_page_columns() {
+	public function hide_columns() {
         if ( ! get_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden' ) ) {
             update_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden', array( 'author', 'comments', 'date' ) );
         }
@@ -569,14 +570,19 @@ class ECommerce {
 		}
     }
 
-	// Add custom column header
-	public function custom_posts_columns($columns) {
+	/**
+	 * Add custom column header for post/page/product screen
+	 */
+	public function custom_status_column($columns) {
 		// Add 'Status' column after 'Title'
 		$columns['status'] = 'Status';
 		return $columns;
 	}
 
-	public function custom_posts_column_content($column_name, $post_id) {	
+	/**
+	 * Shows status and availability under status
+	 */
+	public function custom_status_column_content($column_name, $post_id) {	
 		if ($column_name === 'status') {
 			// Get the post status
 			$post_status = get_post_status($post_id);
@@ -584,9 +590,8 @@ class ECommerce {
 			$post_date = get_post_field('post_date', $post_id);
 			// Get the post visibility
 			$post_visibility = get_post_field('post_password', $post_id);
-			
+
 			$common_style = 'height: 24px; border-radius: 13px 13px 13px 13px;  gap: 16px; padding: 5px 10px; font-weight: 590;font-size: 12px;';
-			
 			if ($post_status === 'publish') {
 				$background_color = empty($post_visibility) ? '#C6E8CA' : '#FDE5CC';
 				$label_text = empty($post_visibility) ? 'Published - Public' : 'Published - Password Protected';
@@ -597,13 +602,20 @@ class ECommerce {
 			}
 			else {
 				$background_color = '#E8ECF0';
-           		 $label_text = $post_status;
+           		$label_text = $post_status;
+			}
+			// Check if coming soon option is enabled
+			$coming_soon = get_option( 'nfd_coming_soon' );
+			if($coming_soon){
+				$background_color = '#E8ECF0';
 			}
 			echo '<span style="background-color: ' . $background_color . '; ' . $common_style . '">' . $label_text . '</span><br> Last Modified: ' . mysql2date('Y/m/d \a\t g:i a', $post_date);
 		}  
 	}
 
-	//Add sorting for the status column
+	/**
+	 * Add sorting for the status column
+	 */
 	public function sortable_product_columns($columns) {
 		$columns['status'] = 'status';
 		return $columns;

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -95,7 +95,7 @@ class ECommerce {
 		add_action( 'before_woocommerce_init', array( $this, 'dismiss_woo_payments_cta' ) );
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'disable_creative_mail_banner' ) );
 		add_action( 'activated_plugin', array( $this, 'detect_plugin_activation' ), 10, 1 );
-		add_action( 'admin_init', array( $this, 'hide_columns' ) );
+		add_action( 'wp_footer', array( $this, 'hide_columns' ) );
 		add_filter( 'manage_posts_columns', array( $this, 'custom_status_column' ), 10, 1 );
 		add_action( 'manage_posts_custom_column', array( $this, 'custom_status_column_content' ), 10, 2 );
 		add_filter( 'manage_pages_columns', array( $this, 'custom_status_column' ), 10, 1 );
@@ -588,7 +588,7 @@ class ECommerce {
 	 * @param int    $post_id Id of post/page
 	 */
 	public function custom_status_column_content( $column_name, $post_id ) {
-		if ( __( 'Status', 'wp-module-ecommerce' ) === $column_name ) {
+		if ( 'status' === $column_name ) {
 			// Get the post status
 			$post_status = get_post_status( $post_id );
 			// Get the post date
@@ -602,10 +602,10 @@ class ECommerce {
 				$label_text       = empty( $post_visibility ) ? __( 'Published - Public', 'wp-module-ecommerce' ) : __( 'Published - Password Protected', 'wp-module-ecommerce' );
 			} elseif ( 'private' === $post_status ) {
 				$background_color = '#CCDCF4';
-				$label_text       = 'Published - Private';
+				$label_text       = __( 'Published - Private', 'wp-module-ecommerce' );
 			} else {
 				$background_color = '#E8ECF0';
-				$label_text       = $post_status;
+				$label_text       = __( $post_status, 'wp-module-ecommerce' );
 			}
 			// Check if coming soon option is enabled
 			$coming_soon = get_option( 'nfd_coming_soon' );

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -647,6 +647,8 @@ class ECommerce {
 		$columns['status'] = 'status';
 		return $columns;
 	}
+
+	/*
 	 *  On login, it checks whether to show the migration steps, post migration to user
 	 */
 	public function show_store_setup() {

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -96,6 +96,13 @@ class ECommerce {
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'disable_creative_mail_banner' ) );
 		add_action( 'activated_plugin', array( $this, 'detect_plugin_activation' ), 10, 1 );
 		add_action( 'admin_init', array( $this, 'hide_page_columns' ) );
+		add_filter('manage_posts_columns', array($this, 'custom_posts_columns'), 10, 1);
+		add_action('manage_posts_custom_column', array($this, 'custom_posts_column_content'), 10, 2);
+		add_filter('manage_pages_columns', array( $this,'custom_posts_columns'), 10, 1 );
+		add_action('manage_pages_custom_column', array($this, 'custom_posts_column_content'), 10, 2);
+		add_filter('manage_edit-product_sortable_columns', array($this, 'sortable_product_columns'));
+		add_filter('manage_edit-post_sortable_columns', array($this, 'sortable_product_columns'));
+		add_filter('manage_edit-page_sortable_columns', array($this, 'sortable_product_columns'));
 
 		$brandNameValue = $container->plugin()->brand;
 		$this->set_wpnav_collapse_setting( $brandNameValue );
@@ -552,10 +559,53 @@ class ECommerce {
      */
 	public function hide_page_columns() {
         if ( ! get_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden' ) ) {
-            update_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden', array( 'author', 'comments' ) );
+            update_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden', array( 'author', 'comments', 'date' ) );
         }
         if ( ! get_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden' ) ) {
-            update_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden', array( 'author', 'categories', 'tags', 'comments' ) );
+            update_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden', array( 'author', 'categories', 'tags', 'comments', 'date' ) );			
         }
+		if ( ! get_user_meta( get_current_user_id(), 'manageedit-productcolumnshidden' ) ) {
+			update_user_meta( get_current_user_id(), 'manageedit-productcolumnshidden', array( 'sku', 'stock', 'date' ) );
+		}
     }
+
+	// Add custom column header
+	public function custom_posts_columns($columns) {
+		// Add 'Status' column after 'Title'
+		$columns['status'] = 'Status';
+		return $columns;
+	}
+
+	public function custom_posts_column_content($column_name, $post_id) {	
+		if ($column_name === 'status') {
+			// Get the post status
+			$post_status = get_post_status($post_id);
+			// Get the post date
+			$post_date = get_post_field('post_date', $post_id);
+			// Get the post visibility
+			$post_visibility = get_post_field('post_password', $post_id);
+			
+			$common_style = 'height: 24px; border-radius: 13px 13px 13px 13px;  gap: 16px; padding: 5px 10px; font-weight: 590;font-size: 12px;';
+			
+			if ($post_status === 'publish') {
+				$background_color = empty($post_visibility) ? '#C6E8CA' : '#FDE5CC';
+				$label_text = empty($post_visibility) ? 'Published - Public' : 'Published - Password Protected';
+			}
+			else if($post_status === 'private'){
+				$background_color = '#CCDCF4';
+            	$label_text = 'Published - Private';
+			}
+			else {
+				$background_color = '#E8ECF0';
+           		 $label_text = $post_status;
+			}
+			echo '<span style="background-color: ' . $background_color . '; ' . $common_style . '">' . $label_text . '</span><br> Last Modified: ' . mysql2date('Y/m/d \a\t g:i a', $post_date);
+		}  
+	}
+
+	//Add sorting for the status column
+	public function sortable_product_columns($columns) {
+		$columns['status'] = 'status';
+		return $columns;
+	}	
 }

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -96,13 +96,13 @@ class ECommerce {
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'disable_creative_mail_banner' ) );
 		add_action( 'activated_plugin', array( $this, 'detect_plugin_activation' ), 10, 1 );
 		add_action( 'admin_init', array( $this, 'hide_columns' ) );
-		add_filter('manage_posts_columns', array($this, 'custom_status_column'), 10, 1);
-		add_action('manage_posts_custom_column', array($this, 'custom_status_column_content'), 10, 2);
-		add_filter('manage_pages_columns', array( $this,'custom_status_column'), 10, 1 );
-		add_action('manage_pages_custom_column', array($this, 'custom_status_column_content'), 10, 2);
-		add_filter('manage_edit-product_sortable_columns', array($this, 'sortable_product_columns'));
-		add_filter('manage_edit-post_sortable_columns', array($this, 'sortable_product_columns'));
-		add_filter('manage_edit-page_sortable_columns', array($this, 'sortable_product_columns'));
+		add_filter( 'manage_posts_columns', array( $this, 'custom_status_column' ), 10, 1 );
+		add_action( 'manage_posts_custom_column', array( $this, 'custom_status_column_content' ), 10, 2 );
+		add_filter( 'manage_pages_columns', array( $this, 'custom_status_column' ), 10, 1 );
+		add_action( 'manage_pages_custom_column', array( $this, 'custom_status_column_content' ), 10, 2 );
+		add_filter( 'manage_edit-product_sortable_columns', array( $this, 'sortable_product_columns' ) );
+		add_filter( 'manage_edit-post_sortable_columns', array( $this, 'sortable_product_columns' ) );
+		add_filter( 'manage_edit-page_sortable_columns', array( $this, 'sortable_product_columns' ) );
 
 		$brandNameValue = $container->plugin()->brand;
 		$this->set_wpnav_collapse_setting( $brandNameValue );
@@ -202,9 +202,8 @@ class ECommerce {
 	public static function set_wpnav_collapse_setting( $brandNameValue ) {
 
 		wp_enqueue_script( 'nfd_wpnavbar_setting', NFD_ECOMMERCE_PLUGIN_URL . 'vendor/newfold-labs/wp-module-ecommerce/includes/wpnavbar.js', array( 'jquery' ), '1.0', true );
-		$params = array('nfdbrandname' => $brandNameValue);
+		$params = array( 'nfdbrandname' => $brandNameValue );
 		wp_localize_script( 'nfd_wpnavbar_setting', 'navBarParams', $params );
-
 	}
 
 	/**
@@ -555,25 +554,27 @@ class ECommerce {
 	/**
 	 * Hide Most columns by default
 	 * Shows title and date in the page/post/product screen by default
-     *
-     * @return void
-     */
+	 *
+	 * @return void
+	 */
 	public function hide_columns() {
-        if ( ! get_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden' ) ) {
-            update_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden', array( 'author', 'comments', 'date' ) );
-        }
-        if ( ! get_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden' ) ) {
-            update_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden', array( 'author', 'categories', 'tags', 'comments', 'date' ) );			
-        }
+		if ( ! get_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden' ) ) {
+			update_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden', array( 'author', 'comments', 'date' ) );
+		}
+		if ( ! get_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden' ) ) {
+			update_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden', array( 'author', 'categories', 'tags', 'comments', 'date' ) );
+		}
 		if ( ! get_user_meta( get_current_user_id(), 'manageedit-productcolumnshidden' ) ) {
 			update_user_meta( get_current_user_id(), 'manageedit-productcolumnshidden', array( 'sku', 'stock', 'date' ) );
 		}
-    }
+	}
 
 	/**
 	 * Add custom column header for post/page/product screen
+	 *
+	 * @param array $columns Array of column names for posts/pages/products
 	 */
-	public function custom_status_column($columns) {
+	public function custom_status_column( $columns ) {
 		// Add 'Status' column after 'Title'
 		$columns['status'] = 'Status';
 		return $columns;
@@ -581,43 +582,47 @@ class ECommerce {
 
 	/**
 	 * Shows status and availability under status
+	 *
+	 * @param string $column_name column names to which content needs to be updated
+	 *
+	 * @param int    $post_id Id of post/page/product
 	 */
-	public function custom_status_column_content($column_name, $post_id) {	
-		if ($column_name === 'status') {
+	public function custom_status_column_content( $column_name, $post_id ) {
+		if ( 'status' === $column_name ) {
 			// Get the post status
-			$post_status = get_post_status($post_id);
+			$post_status = get_post_status( $post_id );
 			// Get the post date
-			$post_date = get_post_field('post_date', $post_id);
+			$post_date = get_post_field( 'post_date', $post_id );
 			// Get the post visibility
-			$post_visibility = get_post_field('post_password', $post_id);
+			$post_visibility = get_post_field( 'post_password', $post_id );
 
 			$common_style = 'height: 24px; border-radius: 13px 13px 13px 13px;  gap: 16px; padding: 5px 10px; font-weight: 590;font-size: 12px;';
-			if ($post_status === 'publish') {
-				$background_color = empty($post_visibility) ? '#C6E8CA' : '#FDE5CC';
-				$label_text = empty($post_visibility) ? 'Published - Public' : 'Published - Password Protected';
-			}
-			else if($post_status === 'private'){
+			if ( 'publish' === $post_status ) {
+				$background_color = empty( $post_visibility ) ? '#C6E8CA' : '#FDE5CC';
+				$label_text       = empty( $post_visibility ) ? 'Published - Public' : 'Published - Password Protected';
+			} elseif ( 'private' === $post_status ) {
 				$background_color = '#CCDCF4';
-            	$label_text = 'Published - Private';
-			}
-			else {
+				$label_text       = 'Published - Private';
+			} else {
 				$background_color = '#E8ECF0';
-           		$label_text = $post_status;
+				$label_text       = $post_status;
 			}
 			// Check if coming soon option is enabled
 			$coming_soon = get_option( 'nfd_coming_soon' );
-			if($coming_soon){
+			if ( $coming_soon ) {
 				$background_color = '#E8ECF0';
 			}
-			echo '<span style="background-color: ' . $background_color . '; ' . $common_style . '">' . $label_text . '</span><br> Last Modified: ' . mysql2date('Y/m/d \a\t g:i a', $post_date);
-		}  
+			echo '<span style="background-color: ' . $background_color . '; ' . $common_style . '">' . $label_text . '</span><br> Last Modified: ' . mysql2date( 'Y/m/d \a\t g:i a', $post_date );
+		}
 	}
 
 	/**
 	 * Add sorting for the status column
+	 *
+	 * @param array $columns Array of column names for posts/pages/products
 	 */
-	public function sortable_product_columns($columns) {
+	public function sortable_product_columns( $columns ) {
 		$columns['status'] = 'status';
 		return $columns;
-	}	
+	}
 }

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -95,6 +95,7 @@ class ECommerce {
 		add_action( 'before_woocommerce_init', array( $this, 'dismiss_woo_payments_cta' ) );
 		add_action( 'load-toplevel_page_' . $container->plugin()->id, array( $this, 'disable_creative_mail_banner' ) );
 		add_action( 'activated_plugin', array( $this, 'detect_plugin_activation' ), 10, 1 );
+		add_action( 'admin_init', array( $this, 'hide_page_columns' ) );
 
 		$brandNameValue = $container->plugin()->brand;
 		$this->set_wpnav_collapse_setting( $brandNameValue );
@@ -543,4 +544,18 @@ class ECommerce {
 			}
 		}
 	}
+
+	/**
+	 * Shows title and date in the page/post screen by default
+     *
+     * @return void
+     */
+	public function hide_page_columns() {
+        if ( ! get_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden' ) ) {
+            update_user_meta( get_current_user_id(), 'manageedit-pagecolumnshidden', array( 'author', 'comments' ) );
+        }
+        if ( ! get_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden' ) ) {
+            update_user_meta( get_current_user_id(), 'manageedit-postcolumnshidden', array( 'author', 'categories', 'tags', 'comments' ) );
+        }
+    }
 }

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -574,7 +574,7 @@ class ECommerce {
 	 * @param array $columns Array of column names for posts/pages
 	 */
 	public function custom_status_column( $columns ) {
-		if ( 'product' != get_post_type() && 1 === get_option( 'onboarding_experience_level' ) ) {
+		if ( 'product' != get_post_type() && 1 == get_option( 'onboarding_experience_level' ) ) {
 			// Add 'Status' column after 'Title'
 			$columns['status'] = 'Status';
 		}


### PR DESCRIPTION
[PRESS0-1119](https://jira.newfold.com/browse/PRESS0-1119) - Add / Alter visual indicator to status/date column
[PRESS0-1141](https://jira.newfold.com/browse/PRESS0-1141) -Disable most columns by default for pages and posts
This change is for Novice users only.

**Live**
Posts
![image](https://github.com/newfold-labs/wp-module-ecommerce/assets/149479917/9691bec5-d28b-4433-a355-f078975960ab)

Pages
![image](https://github.com/newfold-labs/wp-module-ecommerce/assets/149479917/80ba7194-b4d2-4311-8244-471fb4caf743)

**Not Live**
Posts
![image](https://github.com/newfold-labs/wp-module-ecommerce/assets/149479917/f5971c23-77c2-4432-bd79-9dfc7bfd45e2)

Pages
![image](https://github.com/newfold-labs/wp-module-ecommerce/assets/149479917/68bc47bb-d308-44e6-b7f1-35eaeb5d0184)