### PR TITLE
Bugfix: Empty script being loaded from the e-commerce module

### DIFF
--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -381,7 +381,7 @@ class ECommerce {
 			$asset = require $asset_file;
 			\wp_register_script(
 				'nfd-ecommerce-dependency',
-				NFD_ECOMMERCE_PLUGIN_URL . 'vendor/newfold-labs/wp-module-ecommerce/includes/Promotions.js',
+				NFD_ECOMMERCE_PLUGIN_URL . 'vendor/newfold-labs/wp-module-ecommerce/build/index.js',
 				array_merge( $asset['dependencies'], array() ),
 				$asset['version']
 			);

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -381,7 +381,7 @@ class ECommerce {
 			$asset = require $asset_file;
 			\wp_register_script(
 				'nfd-ecommerce-dependency',
-				NFD_ECOMMERCE_PLUGIN_URL,
+				NFD_ECOMMERCE_PLUGIN_URL . 'vendor/newfold-labs/wp-module-ecommerce/includes/Promotions.js',
 				array_merge( $asset['dependencies'], array() ),
 				$asset['version']
 			);


### PR DESCRIPTION
## Proposed changes

`PRESS0-1968` : The Ecommerce module is loading the root plugin directory as a script. 
JIRA: https://jira.newfold.com/browse/PRESS0-1968

Removed

```
\wp_register_script(
  'nfd-ecommerce-dependency',
  NFD_ECOMMERCE_PLUGIN_URL,
  array_merge( $asset['dependencies'], array() ),
  $asset['version']
);

```
Instead registered, 'vendor/newfold-labs/wp-module-ecommerce/build/index.js'  file.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
