### PR TITLE
Move capabilities check behind `admin_init` and `is_admin`

### DIFF
--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -78,9 +78,6 @@ class ECommerce {
 	 * @param Container $container Container loaded from the brand plugin.
 	 */
 	public function __construct( Container $container ) {
-		$capability         = new SiteCapabilities();
-		$hasYithExtended    = $capability->get( 'hasYithExtended' );
-		$canAccessGlobalCTB = $capability->get( 'canAccessGlobalCTB' );
 
 		$this->container = $container;
 		// Module functionality goes here
@@ -110,14 +107,7 @@ class ECommerce {
 		add_action( 'admin_enqueue_scripts', array( $this, 'set_wpnav_collapse_setting' ) );
 		add_action('admin_footer', array( $this, 'remove_woocommerce_ssl_notice' ), 20);
 
-		if ( ( $container->plugin()->id === 'bluehost' && ( $canAccessGlobalCTB || $hasYithExtended ) ) || ( $container->plugin()->id === 'hostgator' && $hasYithExtended ) ) {
-			add_filter( 'admin_menu', array( $this, 'custom_add_promotion_menu_item' ) );
-			add_action( 'woocommerce_product_options_general_product_data', array( $this, 'custom_product_general_options' ) );
-			add_action( 'woocommerce_product_options_related', array( $this, 'custom_product_general_options' ) );
-			add_action( 'woocommerce_product_data_tabs', array( $this, 'custom_product_write_panel_tabs' ) );
-			add_action( 'woocommerce_product_data_panels', array( $this, 'promotion_product_data' ) );
-			add_action( 'admin_head', array( $this, 'action_admin_head' ) );
-		}
+		add_action( 'admin_init', array( $this, 'admin_init_conditional_on_capabilities' ) );
 
 		// Handle WonderCart Integrations
 		if ( is_plugin_active( 'wonder-cart/init.php' ) ) {
@@ -618,6 +608,40 @@ class ECommerce {
 					});
 				</script>
 			<?php
+		}
+	}
+
+	/**
+	 * Add actions and filters that are conditionally added depending on the Site's capabilities.
+	 *
+	 * Running the capabilities check after `admin_init` with `is_admin()` `true` ensures no HTTP requests are made
+	 * for frontend page loads.
+	 *
+	 * `admin_init` runs in `wp-admin/admin.php:175`, `wp-admin/admin-ajax.php:45`, and `wp-admin/admin-post:30`.
+	 * Each of the hooks in this function are UI (HTML) related, so only need to run inside `is_admin()`.
+	 *
+	 * @hooked admin_init
+	 */
+	public function admin_init_conditional_on_capabilities() {
+
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		$capability         = new SiteCapabilities();
+		$hasYithExtended    = $capability->get( 'hasYithExtended' );
+		$canAccessGlobalCTB = $capability->get( 'canAccessGlobalCTB' );
+
+		if (
+				( $this->container->plugin()->id === 'bluehost' && ( $canAccessGlobalCTB || $hasYithExtended ) )
+				|| ( $this->container->plugin()->id === 'hostgator' && $hasYithExtended )
+		) {
+			add_filter( 'admin_menu', array( $this, 'custom_add_promotion_menu_item' ) );
+			add_action( 'woocommerce_product_options_general_product_data', array( $this, 'custom_product_general_options' ) );
+			add_action( 'woocommerce_product_options_related', array( $this, 'custom_product_general_options' ) );
+			add_action( 'woocommerce_product_data_tabs', array( $this, 'custom_product_write_panel_tabs' ) );
+			add_action( 'woocommerce_product_data_panels', array( $this, 'promotion_product_data' ) );
+			add_action( 'admin_head', array( $this, 'action_admin_head' ) );
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes

In the [ECommerce constructor](https://github.com/newfold-labs/wp-module-ecommerce/blob/a4c7c46c83cf54cf99183d442d9abdcf0c90d77e/includes/ECommerce.php#L81-L83) capabilities checks are being used. [In the data module](https://github.com/newfold-labs/wp-module-data/blob/f98dfabe6a4cb10aec6dcd6e81fc7d269238e9a4/includes/SiteCapabilities.php#L22), if the capabilities transient is absent a request is made to Hiive to update it. This expires after four hours.

From what I read, the capabilities checks here are running on every request, meaning every site is polling Hiive for capabilities every four hours.

This change moves the check behind `admin_init` and `is_admin` so the capabilities are only fetched when an admin is accessing `/wp-admin`. The actions and filters that were guarded by the capabilities are all related to admin UI changes (most obviously printing HTML).

https://github.com/newfold-labs/wp-module-ecommerce/commit/8b9c3716568d838345b559f3f1b83fc0ba30152f

https://jira.newfold.com/browse/PRESS0-1016

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

* We are working on related changes in the data module to store the capabilities in an option rather than a transient, and in Hiive to push changes to the capabilities so polling is not necessary.
* It's unclear to me if the failing tests are caused by this change. One of them is ~_expected button not to exist_, and the other could not find the my-products table.