### PR TITLE
Changing admin_init hook to init as it is not firing the promotions tab in side menu

### DIFF
--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -107,7 +107,7 @@ class ECommerce {
 		add_action( 'admin_enqueue_scripts', array( $this, 'set_wpnav_collapse_setting' ) );
 		add_action('admin_footer', array( $this, 'remove_woocommerce_ssl_notice' ), 20);
 
-		add_action( 'admin_init', array( $this, 'admin_init_conditional_on_capabilities' ) );
+		add_action( 'init', array( $this, 'admin_init_conditional_on_capabilities' ) );
 
 		// Handle WonderCart Integrations
 		if ( is_plugin_active( 'wonder-cart/init.php' ) ) {
@@ -624,7 +624,7 @@ class ECommerce {
 	 */
 	public function admin_init_conditional_on_capabilities() {
 
-		if ( ! is_admin() ) {
+		if ( ! ( is_admin() && current_user_can('manage_options') ) ) {
 			return;
 		}
 

--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -105,7 +105,7 @@ class ECommerce {
 		add_action( 'auth_cookie_expired', array( $this, 'show_store_setup' ) );
 		add_action( 'admin_head', array( $this, 'hide_wp_pointer_with_css' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'set_wpnav_collapse_setting' ) );
-		add_action('admin_footer', array( $this, 'remove_woocommerce_ssl_notice' ), 20);
+		add_action( 'admin_footer', array( $this, 'remove_woocommerce_ssl_notice' ), 20 );
 
 		add_action( 'init', array( $this, 'admin_init_conditional_on_capabilities' ) );
 
@@ -582,15 +582,14 @@ class ECommerce {
 	 *
 	 * @return void
 	 */
-
 	public function remove_woocommerce_ssl_notice() {
 
 		// Check if WooCommerce is active.
-		if (!class_exists('WooCommerce')) {
+		if ( ! class_exists( 'WooCommerce' ) ) {
 			return;
 		}
 
-		if (!is_ssl()) {
+		if ( ! is_ssl() ) {
 			// Check if there are any WooCommerce admin notices, find the one with ssl notice link and hide it.
 			?>
 				<script type="text/javascript">
@@ -624,7 +623,7 @@ class ECommerce {
 	 */
 	public function admin_init_conditional_on_capabilities() {
 
-		if ( ! ( is_admin() && current_user_can('manage_options') ) ) {
+		if ( ! ( is_admin() && current_user_can( 'manage_options' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Changing admin_init hook to init as it is not firing the promotions tab in side menu

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
