### PR TITLE
fix: Ensure `check_url_match` function is defined only once

### DIFF
--- a/includes/ECommerce.php
+++ b/includes/ECommerce.php
@@ -712,21 +712,23 @@ class ECommerce {
 
 		$brand = $this->container->plugin()->id;
 
-		/**
-		 * Verifies if the url is matching with the regex
-		 *
-		 * @param string $brand_name id of the brand
-		 *
-		 * @param string $site_url siteurl
-		 */
-		function check_url_match( $brand_name, $site_url ) {
-			switch ( $brand_name ) {
-				case 'bluehost':
-					return ! preg_match( '/\b\w+(\.\w+)*\.mybluehost\.me\b/', $site_url );
-				case 'hostgator':
-					return ! preg_match( '/\b\w+(\.\w+)*\.temporary\.site\b/', $site_url );
-				default:
-					return true;
+		if ( ! function_exists( __NAMESPACE__ . '\check_url_match' ) ) {
+			/**
+			 * Verifies if the url is matching with the regex
+			 *
+			 * @param string $brand_name id of the brand
+			 *
+			 * @param string $site_url siteurl
+			 */
+			function check_url_match( $brand_name, $site_url ) {
+				switch ( $brand_name ) {
+					case 'bluehost':
+						return ! preg_match( '/\b\w+(\.\w+)*\.mybluehost\.me\b/', $site_url );
+					case 'hostgator':
+						return ! preg_match( '/\b\w+(\.\w+)*\.temporary\.site\b/', $site_url );
+					default:
+						return true;
+				}
 			}
 		}
 		if ( check_url_match( $brand, $site_url ) ) {


### PR DESCRIPTION
## Proposed changes

I'm using Bluehost, and the Bluehost plugin relies on this package as a dependency. When registering a new user in our app's frontend, we get this error:

> ```PHP Fatal error:  Cannot redeclare NewfoldLabs\WP\Module\ECommerce\check_url_match() (previously declared in /mysitepath/public_html/wp-content/plugins/bluehost-wordpress-plugin/vendor/newfold-labs/wp-module-ecommerce/includes/ECommerce.php:699) in /mysitepath/public_html/wp-content/plugins/bluehost-wordpress-plugin/vendor/newfold-labs/wp-module-ecommerce/includes/ECommerce.php on line 699```

So this PR aims to fix that.


## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

