### PR TITLE
Only use property in `map()` if its available

### DIFF
--- a/src/components/NoExistingPlan.js
+++ b/src/components/NoExistingPlan.js
@@ -70,7 +70,7 @@ export function NoExistingPlan( props ) {
 							</div>
 							<div className="nfd-flex nfd-flex-row nfd--mt-8">
 								<ul className="nfd-mr-6 nfd-grid nfd-grid-cols-2 nfd-gap-x-6 nfd-mt-6">
-									{ solution?.features.map(
+									{ solution?.features?.map(
 										( feat, index ) => {
 											return (
 												<li


### PR DESCRIPTION
Had an `Uncaught TypeError: Cannot read properties of null (reading 'map')` error popup and noticed it's because we're assuming features is mappable.