### PR TITLE
Add index to list

### DIFF
--- a/src/components/NoExistingPlan.js
+++ b/src/components/NoExistingPlan.js
@@ -74,6 +74,7 @@ export function NoExistingPlan( props ) {
 										( feat, index ) => {
 											return (
 												<li
+													key={ index }
 													className={ classNames(
 														'nfd-flex',
 														'nfd-flex-row',


### PR DESCRIPTION
Fixes the `Warning: Each child in a list should have a unique "key" prop.` console warning.