### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
       contents: write       # Required for the reusable workflow to commit translation updates.
       pull-requests: write  # Required for the reusable workflow to open or update translation pull requests.
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    timeout-minutes: 30
     with:
       text_domain: 'wp-module-ecommerce'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,14 +12,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write       # Required for the reusable workflow to commit translation updates.
+      pull-requests: write  # Required for the reusable workflow to open or update translation pull requests.
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     with:
       text_domain: 'wp-module-ecommerce'

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -18,6 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {}  # Branch name is taken from runner environment variables only.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: read  # Required for the reusable workflow to check out the plugin and module repositories.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,19 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {}  # Branch name is taken from runner environment variables only.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -32,7 +32,7 @@ jobs:
     name: Bluehost Build and Test Playwright
     needs: setup
     permissions:
-      contents: read
+      contents: read  # Required for the reusable workflow to check out the plugin and module repositories.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -20,6 +20,7 @@ permissions: {}
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {}  # No GITHUB_TOKEN usage; only derives the repository name from the github context.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
@@ -34,6 +35,7 @@ jobs:
       contents: write       # Required for the reusable workflow to push coverage reports to gh-pages.
       pull-requests: write  # Required for the reusable workflow to add pull request comments.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    timeout-minutes: 90
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,9 +13,14 @@ on:
       - main
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {}  # No GITHUB_TOKEN usage; only derives the repository name from the github context.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -26,8 +31,8 @@ jobs:
   codecoverage:
     needs: get-repo-name
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write       # Required for the reusable workflow to push coverage reports to gh-pages.
+      pull-requests: write  # Required for the reusable workflow to add pull request comments.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -8,12 +8,14 @@ on:
         required: false
         default: 'main'
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   call-crowdin-workflow:
+    permissions:
+      contents: read  # Required for the reusable workflow to check out this repository (GITHUB_TOKEN); Crowdin uses PAT for PRs.
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     with:
       base_branch: ${{ inputs.base_branch }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: read  # Required for the reusable workflow to check out this repository (GITHUB_TOKEN); Crowdin uses PAT for PRs.
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
+    timeout-minutes: 30
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -3,8 +3,15 @@ name: Crowdin Upload Action
 on:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   call-crowdin-upload-workflow:
+    permissions:
+      contents: write       # Required because the Crowdin action uses GITHUB_TOKEN during source upload (see reusable workflow).
+      pull-requests: write  # Granted to match the called Crowdin workflow's use of GITHUB_TOKEN for pull request updates.
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -13,6 +13,7 @@ jobs:
       contents: write       # Required because the Crowdin action uses GITHUB_TOKEN during source upload (see reusable workflow).
       pull-requests: write  # Granted to match the called Crowdin workflow's use of GITHUB_TOKEN for pull request updates.
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
+    timeout-minutes: 30
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -17,6 +17,7 @@ jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read       # Required to clone this repository for PHPCS on changed PHP files.
       pull-requests: read  # Required for technote-space/get-diff-action to read the pull request diff.

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -9,10 +9,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required to clone this repository for PHPCS on changed PHP files.
+      pull-requests: read  # Required for technote-space/get-diff-action to read the pull request diff.
     steps:
 
       - name: Checkout repository

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -22,8 +22,8 @@ jobs:
   prep-release:
     name: Prepare Release
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write       # Required for the reusable workflow to create release branches and commits.
+      pull-requests: write  # Required for the reusable workflow to open or update the release pull request.
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -25,6 +25,7 @@ jobs:
       contents: write       # Required for the reusable workflow to create release branches and commits.
       pull-requests: write  # Required for the reusable workflow to open or update the release pull request.
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -13,6 +13,7 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions: {}  # No GITHUB_TOKEN usage; repository dispatch uses secrets.WEBHOOK_TOKEN.
     steps:
 

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {}  # No GITHUB_TOKEN usage; repository dispatch uses secrets.WEBHOOK_TOKEN.
     steps:
 
       - name: Set Package

--- a/.github/workflows/wp-i18n.yml
+++ b/.github/workflows/wp-i18n.yml
@@ -7,9 +7,16 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   wp-i18n:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # Required to check out the PR branch and push i18n commits using GITHUB_TOKEN.
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/wp-i18n.yml
+++ b/.github/workflows/wp-i18n.yml
@@ -15,6 +15,7 @@ permissions: {}
 jobs:
   wp-i18n:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write      # Required to check out the PR branch and push i18n commits using GITHUB_TOKEN.
     steps:


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 9 (`auto-translate.yml`, `brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `i18n-crowdin-download.yml`, `i18n-crowdin-upload.yml`, `lint-php.yml`, `newfold-prep-release.yml`, `satis-update.yml`, `wp-i18n.yml`) |
| Branch | `add/scoped-workflow-permissions` (already existed — local commits recreated via rebase; not pushed) |
| Permissions commit | `e6a3f038` |
| Timeouts commit | `43df9731` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-download.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-upload.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `wp-i18n.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| brand-plugin-test-playwright.yml | 1 job lacked an explicit narrowly scoped `permissions:` map aligned with audit rules (converted from broad defaults elsewhere) | setup | `permissions: {}` [3] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| i18n-crowdin-download.yml | 1 job was missing job-level `permissions:` | call-crowdin-workflow | `contents: read` [3] |
| i18n-crowdin-upload.yml | 1 job was missing job-level `permissions:` | call-crowdin-upload-workflow | `contents: write`, `pull-requests: write` [2] |
| lint-php.yml | 1 job was missing job-level `permissions:` | phpcs | `contents: read`, `pull-requests: read` [3] |
| satis-update.yml | 1 job was missing job-level `permissions:` | webhook | `permissions: {}` [3] |
| wp-i18n.yml | 1 job was missing job-level `permissions:` | wp-i18n | `contents: write` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `auto-translate.yml` :: root (preamble/comments only): BEFORE no mandated audit preamble above `permissions: {}` -> AFTER added the two mandated `#` preamble lines contiguously above root `permissions: {}` ahead of `jobs:` -- aligns with pinned audit preamble requirements -- [3] |
| 2 | `auto-translate.yml` :: `translate`: BEFORE bare `contents: write` / `pull-requests: write` (no rationale comments) -> AFTER same scopes with rationale comments added -- satisfies audit inline documentation rule -- [3] |
| 3 | `brand-plugin-test-playwright.yml` :: workflow root: BEFORE `permissions: contents: read` -> AFTER audited `permissions: {}` plus job-level scoping -- removes workflow-wide implicit token scopes -- [3] |
| 4 | `brand-plugin-test-playwright.yml` :: `setup`: BEFORE `permissions: contents: read` -> AFTER `permissions: {}` plus rationale -- unnecessary repo read privilege for extracting branch/ref context only -- [3] |
| 5 | `brand-plugin-test-playwright.yml` :: `bluehost`: BEFORE bare `contents: read` -> AFTER annotated `contents: read` rationale (and structurally satisfies reusable caller ordering rules) -- least-privilege clarification + linter compliance -- [3] |
| 6 | `codecoverage-main.yml` :: `codecoverage`: BEFORE bare `contents: write` / `pull-requests: write` -> AFTER annotated permissions for the reusable caller workflow + correct key ordering (`permissions:` before reusable `uses:`) -- aligns with auditor + complies with reusable workflow caller lint rules -- [3] |
| 7 | `i18n-crowdin-download.yml` :: workflow root: BEFORE broad `permissions: contents: write` + `pull-requests: write` at workflow scope -> AFTER `permissions: {}` with minimal job-level privilege on the reusable caller (`contents: read`) -- reduces overly broad defaults for a workflow-dispatch reusable caller -- [2] |
| 8 | `i18n-crowdin-upload.yml` :: workflow root: BEFORE implicitly defaulting token scopes via missing explicit root policy -> AFTER `permissions: {}` with explicit audited preamble -- establishes explicit deny-by-default workflow token posture -- [2] |
| 9 | `i18n-crowdin-upload.yml` :: `call-crowdin-upload-workflow`: tightened/standardized rationale text for `pull-requests` while keeping mapped scopes documented -- clarifies rationale consistency (ASCII quoting) vs prior ambiguous default-implied scopes -- [2] |
| 10 | `newfold-prep-release.yml` :: `prep-release`: BEFORE bare `contents: write` / `pull-requests: write` -> AFTER annotated rationale (and structurally satisfies reusable caller ordering rules) -- documentation + caller ordering compliance -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| auto-translate.yml | translate | `30` | typical upper bound for a translations automation loop without changing any pre-existing timeouts (none existed). |
| brand-plugin-test-playwright.yml | setup | `10` | quick branch-name extraction helper job; prevents a stuck runner. |
| brand-plugin-test-playwright.yml | bluehost | `120` | Playwright + brand-plugin matrix work can exceed short defaults; capped for runaway prevention. |
| codecoverage-main.yml | get-repo-name | `10` | tiny shell step bounded for runaway prevention. |
| codecoverage-main.yml | codecoverage | `90` | multi-PHP PHPUnit/Codeception + coverage merges can take substantial time versus short defaults. |
| i18n-crowdin-download.yml | call-crowdin-workflow | `30` | reusable Crowdin workflow call bounded vs infinite runs. |
| i18n-crowdin-upload.yml | call-crowdin-upload-workflow | `30` | reusable Crowdin upload call bounded vs infinite runs. |
| lint-php.yml | phpcs | `30` | installs tooling + sniffing on PR paths; reasonable CI ceiling without altering pre-existing values (none existed). |
| newfold-prep-release.yml | prep-release | `30` | release prep reusable workflow bounded for runaway prevention. |
| satis-update.yml | webhook | `30` | short dispatch webhook job bounded despite expected fast completion. |
| wp-i18n.yml | wp-i18n | `30` | WordPress tooling + committing steps should complete well under this cap. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `check_github_workflows_compliance.py` requires reusable workflow callers to declare YAML `permissions:` before `uses:`; call sites were updated accordingly (ordering-only refactor with identical intent). |
| 2 | `i18n-crowdin-upload.yml` job-level scopes mirror the reusable workflow expectations; Crowdin/GitHub-token interactions deserve a human sanity-check against upstream reusable workflow docs if privileges should be tightened further. |
| 3 | Verified locally: `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/scripts/check_github_workflows_compliance.py /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-ecommerce` exits `0`; branch remains unpushed (no upstream configured). |


