### PR TITLE
Bump wp-module-installer dependency to ^1.7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     },
     "require": {
-        "newfold-labs/wp-module-installer": "^1.7.3"
+        "newfold-labs/wp-module-installer": "^1.7.4"
     },
     "require-dev": {
         "johnpbloch/wordpress": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91574622468b90fbb83ebd9b389c2d75",
+    "content-hash": "5e943c06ad3307992a49f7c3f90ebde7",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -313,16 +313,16 @@
         },
         {
             "name": "newfold-labs/wp-module-installer",
-            "version": "1.7.3",
+            "version": "1.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-installer.git",
-                "reference": "6c0471fc9c0a078dacc0628ee37362e8d51aa362"
+                "reference": "3d3b900410fb1699a157d4b22539015769dad32e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-installer/zipball/6c0471fc9c0a078dacc0628ee37362e8d51aa362",
-                "reference": "6c0471fc9c0a078dacc0628ee37362e8d51aa362",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-installer/zipball/3d3b900410fb1699a157d4b22539015769dad32e",
+                "reference": "3d3b900410fb1699a157d4b22539015769dad32e",
                 "shasum": ""
             },
             "require": {
@@ -331,7 +331,7 @@
             "require-dev": {
                 "johnpbloch/wordpress": "6.9.4",
                 "lucatume/wp-browser": "*",
-                "newfold-labs/wp-php-standards": "^1.2.5",
+                "newfold-labs/wp-php-standards": "^1.2.6",
                 "phpunit/phpcov": "*",
                 "wp-cli/i18n-command": "^2.7",
                 "wp-cli/wp-cli": "^2.12"
@@ -370,10 +370,10 @@
                     "vendor/bin/wp i18n update-po ./languages/wp-module-installer.pot ./languages"
                 ],
                 "i18n-php": [
-                    "vendor/bin/wp i18n make-php ./languages"
+                    "vendor/bin/wp i18n make-php ./languages --pretty-print"
                 ],
                 "i18n-json": [
-                    "rm -f languages/*.json && vendor/bin/wp i18n make-json ./languages --no-purge --pretty-print"
+                    "rm -f languages/*.json && vendor/bin/wp i18n make-json ./languages --pretty-print"
                 ],
                 "lint": [
                     "vendor/bin/phpcs --standard=phpcs.xml -s ."
@@ -398,10 +398,10 @@
             ],
             "description": "An installer for WordPress plugins and themes.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-installer/tree/1.7.3",
+                "source": "https://github.com/newfold-labs/wp-module-installer/tree/1.7.4",
                 "issues": "https://github.com/newfold-labs/wp-module-installer/issues"
             },
-            "time": "2026-03-23T19:25:51+00:00"
+            "time": "2026-06-23T10:57:10+00:00"
         },
         {
             "name": "newfold-labs/wp-module-loader",
@@ -10269,6 +10269,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "johnpbloch/wordpress": 0,
+        "newfold-labs/wp-php-standards": 0,
         "wp-cli/i18n-command": 0,
         "wp-cli/wp-cli-bundle": 0
     },


### PR DESCRIPTION
https://newfold.atlassian.net/browse/PRESS0-3627

## Proposed changes

The auto-install of Payments & Shipping added in #930 (`detect_plugin_activation()` → `PluginInstaller::install('nfd_slug_wp_plugin_payments_shipping', true)`) depends on the catalog entry that ships in **wp-module-installer 1.7.4** (added in newfold-labs/wp-module-installer#331, released in tag `1.7.4`).

The current constraint `^1.7.3` also permits the older `1.7.3` release (tagged 2026-03-23, **before** #331), which does **not** contain the `nfd_slug_wp_plugin_payments_shipping` slug. With `^1.7.3`, composer could resolve an installer without that entry — in which case the install call falls through to a `WP_Error` and silently no-ops (no fatal, but the plugin is never installed). The committed `composer.lock` was in fact pinned to the old 1.7.3 (ref `6c0471fc`).

- Bumps `require` constraint: `newfold-labs/wp-module-installer` `^1.7.3` → `^1.7.4`.
- Refreshes `composer.lock` (installer `1.7.3` → `1.7.4`, ref `3d3b9004`) via `composer update newfold-labs/wp-module-installer`. `composer validate` passes.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Further comments

Dependency/lock change only. Guarantees the Payments & Shipping catalog entry is present wherever this module is consumed (e.g. the Bluehost plugin), so the WooCommerce-activation auto-install works as intended.