### PR TITLE
Bump wp-module-installer to ^1.7.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     },
     "require": {
-        "newfold-labs/wp-module-installer": "^1.7.4"
+        "newfold-labs/wp-module-installer": "^1.7.5"
     },
     "require-dev": {
         "johnpbloch/wordpress": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e943c06ad3307992a49f7c3f90ebde7",
+    "content-hash": "a52de47a352d07ce3bf2f6a45b84ea6f",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -313,16 +313,16 @@
         },
         {
             "name": "newfold-labs/wp-module-installer",
-            "version": "1.7.4",
+            "version": "1.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-installer.git",
-                "reference": "3d3b900410fb1699a157d4b22539015769dad32e"
+                "reference": "5e93e1920828b8a0f73f56e3c5891679ded407fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-installer/zipball/3d3b900410fb1699a157d4b22539015769dad32e",
-                "reference": "3d3b900410fb1699a157d4b22539015769dad32e",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-installer/zipball/5e93e1920828b8a0f73f56e3c5891679ded407fb",
+                "reference": "5e93e1920828b8a0f73f56e3c5891679ded407fb",
                 "shasum": ""
             },
             "require": {
@@ -397,11 +397,7 @@
                 }
             ],
             "description": "An installer for WordPress plugins and themes.",
-            "support": {
-                "source": "https://github.com/newfold-labs/wp-module-installer/tree/1.7.4",
-                "issues": "https://github.com/newfold-labs/wp-module-installer/issues"
-            },
-            "time": "2026-06-23T10:57:10+00:00"
+            "time": "2026-06-23T13:21:37+00:00"
         },
         {
             "name": "newfold-labs/wp-module-loader",


### PR DESCRIPTION
https://newfold.atlassian.net/browse/PRESS0-3627

## Proposed changes

Bumps the installer dependency to pick up **wp-module-installer 1.7.5**, which fixes the Payments & Shipping download URL (the `plugin-downloads` endpoint 404'd; 1.7.5 points it at `wp-release-api/plugin/download/wp-plugin-payments-shipping/latest` — newfold-labs/wp-module-installer#335). This sits on top of the 1.7.4 catalog entry (`nfd_slug_wp_plugin_payments_shipping`) that this module installs on WooCommerce activation.

- `require`: `newfold-labs/wp-module-installer` `^1.7.4` → `^1.7.5`.
- `composer.lock` refreshed (installer `1.7.4` → `1.7.5`, ref `5e93e192`); `composer validate` passes.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Further comments

Dependency/lock bump only.