### PR TITLE
Reuse plugin-level WooCommerce install/uninstall helper

### DIFF
--- a/tests/playwright/helpers/index.mjs
+++ b/tests/playwright/helpers/index.mjs
@@ -18,7 +18,7 @@ const finalHelpersPath = join(pluginDir, 'tests/playwright/helpers/index.mjs');
 const helpersUrl = pathToFileURL(finalHelpersPath).href;
 const pluginHelpers = await import(helpersUrl);
 
-export const { auth, wordpress, newfold, a11y, utils, woocommerce } = pluginHelpers;
+export const { auth, wordpress, newfold, a11y, utils } = pluginHelpers;
 
 // ============================================================================
 // CONSTANTS
@@ -84,9 +84,9 @@ export async function setupAndNavigate(page) {
 
 /**
  * Install/uninstall/status helpers for WooCommerce (shared, defined at the plugin level in
- * tests/playwright/helpers/woocommerce.mjs so every module reuses the same implementation).
+ * tests/playwright/helpers/newfold.mjs so every module reuses the same implementation).
  */
-export const { installWooCommerce, isWooCommerceActive, uninstallWooCommerce } = woocommerce;
+export const { installWooCommerce, isWooCommerceActive, uninstallWooCommerce } = newfold;
 
 /**
  * `siteType` as exposed on `window.NewfoldRuntime` (see `Data::runtime()` and `src/app/pages/home/index.js`).

--- a/tests/playwright/helpers/index.mjs
+++ b/tests/playwright/helpers/index.mjs
@@ -18,7 +18,7 @@ const finalHelpersPath = join(pluginDir, 'tests/playwright/helpers/index.mjs');
 const helpersUrl = pathToFileURL(finalHelpersPath).href;
 const pluginHelpers = await import(helpersUrl);
 
-export const { auth, wordpress, newfold, a11y, utils } = pluginHelpers;
+export const { auth, wordpress, newfold, a11y, utils, woocommerce } = pluginHelpers;
 
 // ============================================================================
 // CONSTANTS
@@ -83,25 +83,10 @@ export async function setupAndNavigate(page) {
 }
 
 /**
- * Install and activate WooCommerce plugin
+ * Install/uninstall/status helpers for WooCommerce (shared, defined at the plugin level in
+ * tests/playwright/helpers/woocommerce.mjs so every module reuses the same implementation).
  */
-export async function installWooCommerce() {
-  try {
-    await wordpress.wpCli('plugin install woocommerce --activate', {
-      timeout: 15000,
-    });
-  } catch (error) {
-    utils.fancyLog('Failed to install WooCommerce:' + error.message, 100, 'yellow');
-  }
-}
-
-/**
- * @returns {Promise<boolean>} true if `wp plugin is-active woocommerce` exits 0
- *   (this helper’s wpCli() returns 0 for empty success stdout).
- */
-export async function isWooCommerceActive() {
-  return (await wordpress.wpCli('plugin is-active woocommerce')) === 0;
-}
+export const { installWooCommerce, isWooCommerceActive, uninstallWooCommerce } = woocommerce;
 
 /**
  * `siteType` as exposed on `window.NewfoldRuntime` (see `Data::runtime()` and `src/app/pages/home/index.js`).
@@ -114,33 +99,6 @@ export async function getNewfoldRuntimeSiteType(page) {
   return page.evaluate(() => {
     return globalThis.NewfoldRuntime?.siteType ?? null;
   });
-}
-
-/**
- * Uninstall WooCommerce. Runs `deactivate --uninstall` first; if the plugin
- * is still active (e.g. uninstall step failed), runs `plugin deactivate` so
- * later tests do not run with WooCommerce still active. Repeats up to
- * `maxAttempts` (no unbounded recursion).
- */
-export async function uninstallWooCommerce() {
-  const maxAttempts = 3;
-  for (let i = 0; i < maxAttempts; i++) {
-    if (!(await isWooCommerceActive())) {
-      return;
-    }
-    await wordpress.wpCli('plugin deactivate woocommerce --uninstall');
-    if (!(await isWooCommerceActive())) {
-      return;
-    }
-    await wordpress.wpCli('plugin deactivate woocommerce');
-  }
-  if (await isWooCommerceActive()) {
-    utils.fancyLog(
-      'WooCommerce is still active after multiple deactivate attempts; later tests may fail.',
-      100,
-      'yellow',
-    );
-  }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- `installWooCommerce`/`isWooCommerceActive`/`uninstallWooCommerce` are now re-exported from the host plugin's shared `newfold` helper instead of being defined locally.

## Why
This logic was duplicated between here and `wp-module-coming-soon`, and neither cleaned up companion plugins that assume WooCommerce stays active once installed. The shared implementation (added in newfold-labs/wp-plugin-bluehost#1368, in `tests/playwright/helpers/newfold.mjs` alongside the other third-party plugin integration helpers) also deactivates known WooCommerce-dependent plugins (e.g. `wp-plugin-payments-shipping`) on uninstall, since one of those fataling on `WC_Data_Store` after WooCommerce is removed was cascading into unrelated Playwright failures across the WP 6.9/7.0 test matrix.

## Depends on
Requires a host plugin whose `tests/playwright/helpers/newfold.mjs` exports `installWooCommerce`/`isWooCommerceActive`/`uninstallWooCommerce` — see newfold-labs/wp-plugin-bluehost#1368. Should merge after (or alongside) that PR; the host plugin's composer.lock also needs to be bumped to pick this module version up in its own e2e runs.

## Test plan
- [ ] Run this module's Playwright suite against a host plugin build that includes the updated `newfold.mjs` helper.