### PR TITLE
PRESS0-4968: Limit GitHub Actions token permissions

### DIFF
--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   get-repo-name:
+    permissions: {}
     runs-on: ubuntu-latest
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   call-crowdin-upload-workflow:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -12,6 +12,9 @@ concurrency:
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   webhook:
     name: Send Webhook
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/wp-i18n.yml
+++ b/.github/workflows/wp-i18n.yml
@@ -9,6 +9,8 @@ concurrency:
   cancel-in-progress: true
 jobs:
   wp-i18n:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- add explicit permissions to the five jobs flagged by CodeQL
- deny token access where jobs do not use the repository
- retain write access only where the workflow pushes changes or updates pull requests

## Test plan
- [x] Validate workflow YAML
- [x] Check reusable workflow permission requirements
- [ ] Confirm CodeQL checks pass

https://newfold.atlassian.net/browse/PRESS0-4968